### PR TITLE
Added gitVersionDescriber() command to allow settings

### DIFF
--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
@@ -43,9 +43,11 @@ class GitVersionPlugin implements Plugin<Project> {
     }
 
     private String doDescribe(Project project) {
+
+        Git git = ensureGit(project);
         try {
             String version = ensureDescribeCommand(project).call() ?: UNSPECIFIED_VERSION
-            boolean isClean = ensureGit(project).status().call().isClean()
+            boolean isClean = git.status().call().isClean()
             return version + (isClean ? '' : '.dirty')
 
         } catch (Throwable t) {
@@ -55,7 +57,7 @@ class GitVersionPlugin implements Plugin<Project> {
 
     private DescribeCommand ensureDescribeCommand(Project project) {
         if (describeCommand == null) {
-            Git git = ensureGit()
+            Git git = ensureGit(project)
             describeCommand = git.describe()
         }
 

--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.gradle.gitversion;
+package com.palantir.gradle.gitversion
 
+import org.eclipse.jgit.api.DescribeCommand
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.internal.storage.file.FileRepository
 import org.gradle.api.Plugin
@@ -24,27 +25,55 @@ class GitVersionPlugin implements Plugin<Project> {
 
     // Gradle returns 'unspecified' when no version is set
     private static final String UNSPECIFIED_VERSION = 'unspecified'
+    private DescribeCommand describeCommand = null
+    private Git git;
 
     void apply(Project project) {
         project.ext.gitVersion = {
-            File gitDir = new File(project.rootDir, '.git')
-            if (!gitDir.exists()) {
-                throw new IllegalArgumentException('Cannot find \'.git\' directory')
-            }
+            doDescribe(project)
+        }
 
-            try {
-                Git git = Git.wrap(new FileRepository(gitDir))
-                String version = git.describe().call() ?: UNSPECIFIED_VERSION
-                boolean isClean = git.status().call().isClean()
-                return version + (isClean ? '' : '.dirty')
-            } catch (Throwable t) {
-                return UNSPECIFIED_VERSION
-            }
+        project.ext.gitVersionDescriber = {
+            return ensureDescribeCommand(project)
         }
 
         project.tasks.create('printVersion') << {
             println project.version
         }
+    }
+
+    private String doDescribe(Project project) {
+        try {
+            String version = ensureDescribeCommand(project).call() ?: UNSPECIFIED_VERSION
+            boolean isClean = ensureGit(project).status().call().isClean()
+            return version + (isClean ? '' : '.dirty')
+
+        } catch (Throwable t) {
+            return UNSPECIFIED_VERSION
+        }
+    }
+
+    private DescribeCommand ensureDescribeCommand(Project project) {
+        if (describeCommand == null) {
+            Git git = ensureGit()
+            describeCommand = git.describe()
+        }
+
+        return describeCommand
+    }
+
+    private Git ensureGit(Project project) {
+        if (git == null) {
+            File gitDir = new File(project.rootDir, '.git')
+
+            if (!gitDir.exists()) {
+                throw new IllegalArgumentException('Cannot find \'.git\' directory')
+            }
+
+            git = Git.wrap(new FileRepository(gitDir))
+        }
+
+        return git
     }
 }
 


### PR DESCRIPTION
The idea is to allow the script to use the equivalent of "git describe --long" by getting the version describer and allowing the script to do whatever it wants with it.

It was necessary to go through some refactoring of GitVersionPlugin.groovy to allow this to happen.
I added a test case and refactored repetitive git commands to private methods.
