### PR TITLE
return dummy VersionDetails object when version is unspecified

### DIFF
--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
@@ -71,11 +71,7 @@ class GitVersionPlugin implements Plugin<Project> {
             String description = gitDesc(project)
             String hash = gitHash(project)
 
-            if (description.equals(UNSPECIFIED_VERSION)) {
-                return null
-            }
-
-            if (!(description =~ /.*g.?[0-9a-fA-F]{3,}/)) {
+            if (!(description =~ /.*g.?[0-9a-fA-F]{3,}/) || description.equals(UNSPECIFIED_VERSION)) {
                 // Description has no git hash so it is just the tag name
                 return new VersionDetails(description, 0, hash)
             }

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -215,7 +215,9 @@ class GitVersionPluginTests extends Specification {
             }
             version gitVersion()
             task printVersionDetails() << {
-                println versionDetails()
+                println versionDetails().lastTag
+                println versionDetails().commitDistance
+                println versionDetails().gitHash
             }
         '''.stripIndent()
         Git git = Git.init().setDirectory(projectDir).call();
@@ -224,7 +226,7 @@ class GitVersionPluginTests extends Specification {
         BuildResult buildResult = with('printVersionDetails').build()
 
         then:
-        buildResult.output.contains(':printVersionDetails\nnull\n')
+        buildResult.output.contains(':printVersionDetails\nunspecified\n0\nunspecified\n')
     }
 
     def 'version details on commit with a tag' () {


### PR DESCRIPTION
When version is unspecified, user will get an error when trying to obtain properties from VersionDetails

```
details.lastTag
details.commitDistance
details.gitHash
```

instead of checking for null before accessing these properties, can we just return a dummy object?
