### PR TITLE
change .dirty to -dirty

### DIFF
--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
@@ -47,7 +47,7 @@ class GitVersionPlugin implements Plugin<Project> {
             DescribeFirstParentCommand describe = new DescribeFirstParentCommand(git.getRepository())
             String version = describe.call() ?: UNSPECIFIED_VERSION
             boolean isClean = git.status().call().isClean()
-            return version + (isClean ? '' : '.dirty')
+            return version + (isClean ? '' : '-dirty')
         } catch (Throwable t) {
             return UNSPECIFIED_VERSION
         }

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -134,7 +134,7 @@ class GitVersionPluginTests extends Specification {
         BuildResult buildResult = with('printVersion').build()
 
         then:
-        buildResult.output.contains(':printVersion\nunspecified.dirty\n')
+        buildResult.output.contains(':printVersion\nunspecified-dirty\n')
     }
 
     def 'git describe when annotated tag is present' () {
@@ -248,7 +248,7 @@ class GitVersionPluginTests extends Specification {
         BuildResult buildResult = with('printVersion').build()
 
         then:
-        buildResult.output.contains(':printVersion\n1.0.0.dirty\n')
+        buildResult.output.contains(':printVersion\n1.0.0-dirty\n')
     }
 
     def 'git describe and clean when symlink is present' () {


### PR DESCRIPTION
This makes versions created by this plugin fully compatible with the SLS spec (I'd link but that repo is no longer public). This commit is a result of a discussion on the SLS spec.

Probably should bump the major version of this plugin after this commit since it could break people's workflows.