### PR TITLE
bump configuration-resolver to 0.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.jfrog.bintray' version '1.5'
     id 'com.gradle.plugin-publish' version '0.9.2'
-    id 'com.palantir.configuration-resolver' version '0.1.0'
+    id 'com.palantir.configuration-resolver' version '0.2.0'
     id 'com.palantir.git-version' version '0.4.0'
     id 'com.palantir.idea-test-fix' version '0.1.0'
     id 'eclipse'


### PR DESCRIPTION
To pick up this fix: https://github.com/palantir/gradle-configuration-resolver-plugin/pull/26. Otherwise, I hit this error with gradle 3.4.*: https://github.com/palantir/gradle-configuration-resolver-plugin/issues/25

