### PR TITLE
Bump jgit version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile 'org.eclipse.jgit:org.eclipse.jgit:4.1.1.201511131810-r'
+    compile 'org.eclipse.jgit:org.eclipse.jgit:4.5.2.201704071617-r'
 
     testCompile gradleTestKit()
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {


### PR DESCRIPTION
Bumping the jgit version used in gradle-git-version. In jgit versions < 4.5, submodules added to a repo would lead to the repo always being marked dirty regardless of actual dirty state. Documented here: https://bugs.eclipse.org/bugs/show_bug.cgi?id=391280