### PR TITLE
Add VersionDetails#isCleanTag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ details.lastTag
 details.commitDistance
 details.gitHash
 details.branchName // is null if the repository in detached HEAD mode
-details.isTag // true if a tag is checked out and repository is not dirty
+details.isCleanTag
 ```
 
 Tasks

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@ details.lastTag
 details.commitDistance
 details.gitHash
 details.branchName // is null if the repository in detached HEAD mode
+details.isTag // true if a tag is checked out and repository is not dirty
 ```
 
 Tasks

--- a/src/main/groovy/com/palantir/gradle/gitversion/GitCli.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitCli.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015 Palantir Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * <http://www.apache.org/licenses/LICENSE-2.0>
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.gradle.gitversion
+
+class GitCli {
+    private GitCli() {}
+
+    static void verifyGitCommandExists() {
+        Process gitVersionProcess = new ProcessBuilder("git", "version").start()
+        if (gitVersionProcess.waitFor() != 0) {
+            throw new IllegalStateException("error invoking git command")
+        }
+    }
+
+    static String runGitCommand(File dir, String... commands) {
+        List<String> cmdInput = new ArrayList<>()
+        cmdInput.add("git")
+        cmdInput.addAll(commands)
+        ProcessBuilder pb = new ProcessBuilder(cmdInput)
+        pb.directory(dir)
+        pb.redirectErrorStream(true)
+
+        Process process = pb.start()
+        BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))
+
+        StringBuilder builder = new StringBuilder()
+        String line = null
+        while ((line = reader.readLine()) != null) {
+            builder.append(line)
+            builder.append(System.getProperty("line.separator"))
+        }
+
+        int exitCode = process.waitFor()
+        if (exitCode != 0) {
+            return ""
+        }
+
+        return builder.toString().trim()
+    }
+
+    static File getRootGitDir(File currentRoot) {
+        File gitDir = scanForRootGitDir(currentRoot)
+        if (!gitDir.exists()) {
+            throw new IllegalArgumentException('Cannot find \'.git\' directory')
+        }
+        return gitDir
+    }
+
+    private static File scanForRootGitDir(File currentRoot) {
+        File gitDir = new File(currentRoot, '.git')
+
+        if (gitDir.exists()) {
+            return gitDir
+        }
+
+        // stop at the root directory, return non-existing File object
+        if (currentRoot.parentFile == null) {
+            return gitDir
+        }
+
+        // look in parent directory
+        return scanForRootGitDir(currentRoot.parentFile)
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
@@ -20,6 +20,7 @@ import org.eclipse.jgit.api.DescribeCommand
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.internal.storage.file.FileRepository
 import org.eclipse.jgit.lib.Constants
+import org.eclipse.jgit.lib.ObjectId
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -61,7 +62,11 @@ class GitVersionPlugin implements Plugin<Project> {
     @Memoized
     private String gitHash(Project project) {
         Git git = gitRepo(project)
-        return git.getRepository().getRef("HEAD").getObjectId().abbreviate(VERSION_ABBR_LENGTH).name()
+        ObjectId objectId = git.getRepository().getRef("HEAD").getObjectId();
+        if (objectId == null) {
+            return null
+        }
+        return objectId.abbreviate(VERSION_ABBR_LENGTH).name()
     }
 
     @Memoized
@@ -78,10 +83,6 @@ class GitVersionPlugin implements Plugin<Project> {
     @Memoized
     private VersionDetails versionDetails(Project project) {
         String description = gitDescribe(project)
-        if (description.equals(UNSPECIFIED_VERSION)) {
-            return null
-        }
-
         String hash = gitHash(project)
         String branchName = gitBranchName(project)
 
@@ -90,7 +91,7 @@ class GitVersionPlugin implements Plugin<Project> {
 
     void apply(Project project) {
         project.ext.gitVersion = {
-            return gitDescribe(project)
+            return versionDetails(project).description
         }
 
         project.ext.versionDetails = {

--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
@@ -60,6 +60,12 @@ class GitVersionPlugin implements Plugin<Project> {
     }
 
     @Memoized
+    private boolean isClean(Project project) {
+        Git git = gitRepo(project)
+        return git.status().call().isClean();
+    }
+
+    @Memoized
     private String gitHash(Project project) {
         Git git = gitRepo(project)
         ObjectId objectId = git.getRepository().getRef("HEAD").getObjectId();
@@ -85,8 +91,9 @@ class GitVersionPlugin implements Plugin<Project> {
         String description = gitDescribe(project)
         String hash = gitHash(project)
         String branchName = gitBranchName(project)
+        boolean isClean = isClean(project)
 
-        return new VersionDetails(description, hash, branchName)
+        return new VersionDetails(description, hash, branchName, isClean)
     }
 
     void apply(Project project) {

--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
@@ -21,6 +21,7 @@ import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.internal.storage.file.FileRepository
 import org.eclipse.jgit.lib.Constants
 import org.eclipse.jgit.lib.ObjectId
+import org.eclipse.jgit.lib.Ref
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -74,12 +75,11 @@ class GitVersionPlugin implements Plugin<Project> {
     @Memoized
     private String gitBranchName(Project project) {
         Git git = gitRepo(project)
-        def ref = git.repository.getRef(git.repository.branch)
+        Ref ref = git.repository.getRef(git.repository.branch)
         if (ref == null) {
             return null
-        } else {
-            return ref.getName().substring(Constants.R_HEADS.length())
         }
+        return ref.getName().substring(Constants.R_HEADS.length())
     }
 
     @Memoized

--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
@@ -23,8 +23,6 @@ import org.eclipse.jgit.lib.Constants
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-import java.util.regex.Matcher
-
 class GitVersionPlugin implements Plugin<Project> {
 
     // Gradle returns 'unspecified' when no version is set
@@ -87,16 +85,7 @@ class GitVersionPlugin implements Plugin<Project> {
         String hash = gitHash(project)
         String branchName = gitBranchName(project)
 
-        if (!(description =~ /.*g.?[0-9a-fA-F]{3,}/)) {
-            // Description has no git hash so it is just the tag name
-            return new VersionDetails(description, 0, hash, branchName)
-        }
-
-        Matcher match = (description =~ /(.*)-([0-9]+)-g.?[0-9a-fA-F]{3,}/)
-        String tagName = match[0][1]
-        int commitCount = Integer.valueOf(match[0][2])
-
-        return new VersionDetails(tagName, commitCount, hash, branchName)
+        return new VersionDetails(description, hash, branchName)
     }
 
     void apply(Project project) {

--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
@@ -26,8 +26,6 @@ import org.gradle.api.Project
 
 class GitVersionPlugin implements Plugin<Project> {
 
-    // Gradle returns 'unspecified' when no version is set
-    private static final String UNSPECIFIED_VERSION = 'unspecified'
     private static final int VERSION_ABBR_LENGTH = 10
 
     @Memoized
@@ -51,11 +49,9 @@ class GitVersionPlugin implements Plugin<Project> {
             // first to preserve this behavior in cases where this call would fail but native "git" call does not.
             new DescribeCommand(git.getRepository()).call()
 
-            String version = runGitCommand(project.rootDir, "describe", "--tags", "--always", "--first-parent") ?: UNSPECIFIED_VERSION
-            boolean isClean = git.status().call().isClean()
-            return version + (isClean ? '' : '.dirty')
+            return runGitCommand(project.rootDir, "describe", "--tags", "--always", "--first-parent")
         } catch (Throwable t) {
-            return UNSPECIFIED_VERSION
+            return null
         }
     }
 
@@ -98,7 +94,7 @@ class GitVersionPlugin implements Plugin<Project> {
 
     void apply(Project project) {
         project.ext.gitVersion = {
-            return versionDetails(project).description
+            return versionDetails(project).version
         }
 
         project.ext.versionDetails = {

--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
@@ -42,7 +42,7 @@ class GitVersionPlugin implements Plugin<Project> {
     }
 
     @Memoized
-    private String gitDesc(Project project) {
+    private String gitDescribe(Project project) {
         // verify that "git" command exists (throws exception if it does not)
         verifyGitCommandExists()
 
@@ -79,11 +79,11 @@ class GitVersionPlugin implements Plugin<Project> {
 
     void apply(Project project) {
         project.ext.gitVersion = {
-            return gitDesc(project)
+            return gitDescribe(project)
         }
 
         project.ext.versionDetails = {
-            String description = gitDesc(project)
+            String description = gitDescribe(project)
             if (description.equals(UNSPECIFIED_VERSION)) {
                 return null
             }

--- a/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
@@ -30,13 +30,15 @@ class VersionDetails implements Serializable {
     final int commitDistance;
     final String gitHash;
     final String branchName;
-    final boolean isTag;
 
     public VersionDetails(String lastTag, int commitDistance, String gitHash, String branchName) {
         this.lastTag = lastTag;
         this.commitDistance = commitDistance;
         this.gitHash = gitHash;
         this.branchName = branchName;
-        this.isTag = commitDistance == 0;
+    }
+
+    public boolean getIsTag() {
+        return commitDistance == 0;
     }
 }

--- a/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
@@ -30,12 +30,13 @@ class VersionDetails implements Serializable {
     final int commitDistance;
     final String gitHash;
     final String branchName;
+    final boolean isTag;
 
     public VersionDetails(String lastTag, int commitDistance, String gitHash, String branchName) {
         this.lastTag = lastTag;
         this.commitDistance = commitDistance;
         this.gitHash = gitHash;
-        this.branchName = branchName
+        this.branchName = branchName;
+        this.isTag = commitDistance == 0;
     }
-
 }

--- a/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
@@ -48,11 +48,11 @@ class VersionDetails implements Serializable {
     }
 
     public boolean getIsCleanTag() {
-        return isClean && !descriptionContainsCommitHash();
+        return isClean && descriptionIsPlainTag();
     }
 
     public int getCommitDistance() {
-        if (!descriptionContainsCommitHash()) {
+        if (descriptionIsPlainTag()) {
             return 0;
         }
 
@@ -62,7 +62,7 @@ class VersionDetails implements Serializable {
     }
 
     public String getLastTag() {
-        if (!descriptionContainsCommitHash()) {
+        if (descriptionIsPlainTag()) {
             return description;
         }
 
@@ -71,7 +71,7 @@ class VersionDetails implements Serializable {
         return tagName;
     }
 
-    private boolean descriptionContainsCommitHash() {
-        return description =~ /.*g.?[0-9a-fA-F]{3,}/;
+    private boolean descriptionIsPlainTag() {
+        return !(description =~ /.*g.?[0-9a-fA-F]{3,}/);
     }
 }

--- a/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
@@ -31,11 +31,13 @@ class VersionDetails implements Serializable {
     final String description;
     final String gitHash;
     final String branchName;
+    final boolean isClean;
 
-    public VersionDetails(String description, String gitHash, String branchName) {
+    public VersionDetails(String description, String gitHash, String branchName, boolean isClean) {
         this.description = description;
         this.gitHash = gitHash;
         this.branchName = branchName;
+        this.isClean = isClean;
     }
 
     public boolean getIsTag() {

--- a/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
@@ -17,6 +17,8 @@ package com.palantir.gradle.gitversion;
 
 import groovy.transform.*
 
+import java.util.regex.Matcher
+
 /**
  * POGO containing the tag name and commit count that make
  * up the version string.
@@ -26,19 +28,38 @@ import groovy.transform.*
 class VersionDetails implements Serializable {
     private static final long serialVersionUID = -7340444937169877612L;
 
-    final String lastTag;
-    final int commitDistance;
+    final String description;
     final String gitHash;
     final String branchName;
 
-    public VersionDetails(String lastTag, int commitDistance, String gitHash, String branchName) {
-        this.lastTag = lastTag;
-        this.commitDistance = commitDistance;
+    public VersionDetails(String description, String gitHash, String branchName) {
+        this.description = description;
         this.gitHash = gitHash;
         this.branchName = branchName;
     }
 
     public boolean getIsTag() {
         return commitDistance == 0;
+    }
+
+    public int getCommitDistance() {
+        if (!(description =~ /.*g.?[0-9a-fA-F]{3,}/)) {
+            // Description has no git hash so it is just the tag name
+            return 0;
+        }
+
+        Matcher match = (description =~ /(.*)-([0-9]+)-g.?[0-9a-fA-F]{3,}/)
+        int commitCount = Integer.valueOf(match[0][2])
+        return commitCount;
+    }
+
+    public String getLastTag() {
+        if (!(description =~ /.*g.?[0-9a-fA-F]{3,}/)) {
+            return description;
+        }
+
+        Matcher match = (description =~ /(.*)-([0-9]+)-g.?[0-9a-fA-F]{3,}/)
+        String tagName = match[0][1]
+        return tagName;
     }
 }

--- a/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
@@ -26,6 +26,9 @@ import java.util.regex.Matcher
 @ToString
 @EqualsAndHashCode
 class VersionDetails implements Serializable {
+
+    // Gradle returns 'unspecified' when no version is set
+    private static final String UNSPECIFIED_VERSION = 'unspecified'
     private static final long serialVersionUID = -7340444937169877612L;
 
     final String description;
@@ -38,6 +41,14 @@ class VersionDetails implements Serializable {
         this.gitHash = gitHash;
         this.branchName = branchName;
         this.isClean = isClean;
+    }
+
+    public String getVersion() {
+        if (description == null) {
+            return UNSPECIFIED_VERSION
+        }
+
+        return description + (isClean ? '' : '.dirty')
     }
 
     public boolean getIsTag() {

--- a/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
@@ -51,8 +51,8 @@ class VersionDetails implements Serializable {
         return description + (isClean ? '' : '.dirty')
     }
 
-    public boolean getIsTag() {
-        return commitDistance == 0;
+    public boolean getIsCleanTag() {
+        return isClean && getCommitDistance() == 0;
     }
 
     public int getCommitDistance() {

--- a/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
@@ -19,10 +19,6 @@ import groovy.transform.*
 
 import java.util.regex.Matcher
 
-/**
- * POGO containing the tag name and commit count that make
- * up the version string.
- */
 @ToString
 @EqualsAndHashCode
 class VersionDetails implements Serializable {
@@ -52,12 +48,11 @@ class VersionDetails implements Serializable {
     }
 
     public boolean getIsCleanTag() {
-        return isClean && getCommitDistance() == 0;
+        return isClean && !descriptionContainsCommitHash();
     }
 
     public int getCommitDistance() {
-        if (!(description =~ /.*g.?[0-9a-fA-F]{3,}/)) {
-            // Description has no git hash so it is just the tag name
+        if (!descriptionContainsCommitHash()) {
             return 0;
         }
 
@@ -67,12 +62,16 @@ class VersionDetails implements Serializable {
     }
 
     public String getLastTag() {
-        if (!(description =~ /.*g.?[0-9a-fA-F]{3,}/)) {
+        if (!descriptionContainsCommitHash()) {
             return description;
         }
 
         Matcher match = (description =~ /(.*)-([0-9]+)-g.?[0-9a-fA-F]{3,}/)
         String tagName = match[0][1]
         return tagName;
+    }
+
+    private boolean descriptionContainsCommitHash() {
+        return description =~ /.*g.?[0-9a-fA-F]{3,}/;
     }
 }

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -283,6 +283,26 @@ class GitVersionPluginTests extends Specification {
         buildResult.output.contains(':printVersion\n1.0.0\n')
     }
 
+    def 'version details not null when no tags are present' () {
+        given:
+        buildFile << '''
+            plugins {
+                id 'com.palantir.git-version'
+            }
+            version gitVersion()
+            task printVersionDetails() << {
+                println versionDetails()
+            }
+        '''.stripIndent()
+        Git git = Git.init().setDirectory(projectDir).call();
+
+        when:
+        BuildResult buildResult = with('printVersionDetails').build()
+
+        then:
+        buildResult.output.contains(':printVersionDetails\ncom.palantir.gradle.gitversion.VersionDetails(null, null, null, false)\n')
+    }
+
     def 'version details on commit with a tag' () {
         given:
         buildFile << '''

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -315,6 +315,7 @@ class GitVersionPluginTests extends Specification {
                 println versionDetails().commitDistance
                 println versionDetails().gitHash
                 println versionDetails().branchName
+                println versionDetails().isTag
             }
         '''.stripIndent()
         gitIgnoreFile << 'build'
@@ -327,7 +328,7 @@ class GitVersionPluginTests extends Specification {
         BuildResult buildResult = with('printVersionDetails').build()
 
         then:
-        buildResult.output =~ ":printVersionDetails\n1.0.0\n0\n[a-z0-9]{10}\nmaster\n"
+        buildResult.output =~ ":printVersionDetails\n1.0.0\n0\n[a-z0-9]{10}\nmaster\ntrue\n"
     }
 
     def 'version details when commit distance to tag is > 0' () {
@@ -342,6 +343,7 @@ class GitVersionPluginTests extends Specification {
                 println versionDetails().commitDistance
                 println versionDetails().gitHash
                 println versionDetails().branchName
+                println versionDetails().isTag
             }
 
         '''.stripIndent()
@@ -356,7 +358,7 @@ class GitVersionPluginTests extends Specification {
         BuildResult buildResult = with('printVersionDetails').build()
 
         then:
-        buildResult.output =~ ":printVersionDetails\n1.0.0\n1\n[a-z0-9]{10}\nmaster\n"
+        buildResult.output =~ ":printVersionDetails\n1.0.0\n1\n[a-z0-9]{10}\nmaster\nfalse\n"
     }
 
     def 'version details when detached HEAD mode' () {

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -283,26 +283,6 @@ class GitVersionPluginTests extends Specification {
         buildResult.output.contains(':printVersion\n1.0.0\n')
     }
 
-    def 'version details null when no tags are present' () {
-        given:
-        buildFile << '''
-            plugins {
-                id 'com.palantir.git-version'
-            }
-            version gitVersion()
-            task printVersionDetails() << {
-                println versionDetails()
-            }
-        '''.stripIndent()
-        Git git = Git.init().setDirectory(projectDir).call();
-
-        when:
-        BuildResult buildResult = with('printVersionDetails').build()
-
-        then:
-        buildResult.output.contains(':printVersionDetails\nnull\n')
-    }
-
     def 'version details on commit with a tag' () {
         given:
         buildFile << '''


### PR DESCRIPTION
fixes #57 

Instead of the common boilerplate:

```groovy
def isRelease = (project.version.toString() ==~ /[0-9]+(\.[0-9]+)+((-(beta|rc)[0-9]{1,2})(\.[0-9])?)?/)
dockerPush.onlyIf { isRelease }
```

You can now write:

```groovy
dockerPush.onlyIf { gitVersion().isCleanTag }
```

A tiny refactor was necessary to do this in a non-nasty way... the `VersionDetails` class now has some getters that derive information from the raw info we get from git.

Wasn't 100% sure what to call the field... `isRelease` seemed a bit presumptuous (people might have funny tags like 1.2.3-dev), so I figured `isCleanTag` was the minimal description...

What do you think @uschi2000 / @markelliot?