### PR TITLE
Allow definition of a tag prefix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,14 @@ details.branchName // is null if the repository in detached HEAD mode
 details.isCleanTag
 ```
 
+You can optionally search a subset of tags with `prefix`. Inclusion of the `prefix` in the returned version is toggled
+with `includePrefix` (default: `false`). Example when the tag is my-product2.15.0:
+
+```groovy
+gitVersion(prefix:'my-product') // -> 2.15.0
+gitVersion(prefix:'my-product', includePrefix:true) // -> my-product2.15.0
+```
+
 Tasks
 -----
 This plugin adds a `printVersion` task, which will echo the project's configured version

--- a/readme.md
+++ b/readme.md
@@ -39,10 +39,18 @@ details.branchName // is null if the repository in detached HEAD mode
 details.isCleanTag
 ```
 
-You can optionally search a subset of tags with `prefix`. Example when the tag is my-product2.15.0:
+You can optionally search a subset of tags with `prefix`. Example when the tag is my-product@2.15.0:
 
 ```groovy
-gitVersion(prefix:'my-product') // -> 2.15.0
+gitVersion(prefix:'my-product@') // -> 2.15.0
+```
+
+Valid prefixes are defined by the regex `[/@]?([A-Za-z]+[/@-])+`.
+```
+/Abc/
+Abc@
+foo-bar@
+foo/bar@
 ```
 
 Tasks

--- a/readme.md
+++ b/readme.md
@@ -39,12 +39,10 @@ details.branchName // is null if the repository in detached HEAD mode
 details.isCleanTag
 ```
 
-You can optionally search a subset of tags with `prefix`. Inclusion of the `prefix` in the returned version is toggled
-with `includePrefix` (default: `false`). Example when the tag is my-product2.15.0:
+You can optionally search a subset of tags with `prefix`. Example when the tag is my-product2.15.0:
 
 ```groovy
 gitVersion(prefix:'my-product') // -> 2.15.0
-gitVersion(prefix:'my-product', includePrefix:true) // -> my-product2.15.0
 ```
 
 Tasks

--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionArgs.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionArgs.groovy
@@ -1,0 +1,6 @@
+package com.palantir.gradle.gitversion
+
+class GitVersionArgs {
+    String prefix = ''
+    boolean includePrefix = false
+}

--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionArgs.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionArgs.groovy
@@ -2,5 +2,4 @@ package com.palantir.gradle.gitversion
 
 class GitVersionArgs {
     String prefix = ''
-    boolean includePrefix = false
 }

--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
@@ -49,17 +49,13 @@ class GitVersionPlugin implements Plugin<Project> {
         }
     }
 
-    private static String optionallyStripPrefix(String description, String prefix, boolean includePrefix) {
-        if (!description) {
-            return description
-        }
-        return includePrefix ? description : description.replaceFirst("^${prefix}", "")
+    private static String stripPrefix(String description, String prefix) {
+        return !description ? description : description.replaceFirst("^${prefix}", "")
     }
 
     @Memoized
     private VersionDetails versionDetails(Project project, GitVersionArgs args) {
-        String description =
-                optionallyStripPrefix(gitDescribe(project, args.prefix), args.prefix, args.includePrefix)
+        String description = stripPrefix(gitDescribe(project, args.prefix), args.prefix)
         String hash = gitHash(project)
         String branchName = gitBranchName(project)
         boolean isClean = isClean(project)

--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
@@ -28,15 +28,16 @@ import org.gradle.api.Project
 class GitVersionPlugin implements Plugin<Project> {
 
     private static final int VERSION_ABBR_LENGTH = 10
+    private static final String PREFIX_REGEX = "[/@]?([A-Za-z]+[/@-])+"
 
     void apply(Project project) {
         project.ext.gitVersion = {
-            args=[:] ->
+            args = [:] ->
                 return versionDetails(project, args as GitVersionArgs).version
         }
 
         project.ext.versionDetails = {
-            args=[:] ->
+            args = [:] ->
                 return versionDetails(project, args as GitVersionArgs)
         }
 
@@ -49,12 +50,18 @@ class GitVersionPlugin implements Plugin<Project> {
         }
     }
 
+    static void verifyPrefix(String prefix) {
+        assert prefix != null && (prefix == "" || prefix.matches(PREFIX_REGEX)),
+                "Specified prefix `${prefix}` does not match the allowed format regex `${PREFIX_REGEX}`."
+    }
+
     private static String stripPrefix(String description, String prefix) {
         return !description ? description : description.replaceFirst("^${prefix}", "")
     }
 
     @Memoized
     private VersionDetails versionDetails(Project project, GitVersionArgs args) {
+        verifyPrefix(args.prefix)
         String description = stripPrefix(gitDescribe(project, args.prefix), args.prefix)
         String hash = gitHash(project)
         String branchName = gitBranchName(project)

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -416,31 +416,7 @@ class GitVersionPluginTests extends Specification {
         buildResult.output =~ ":printVersionDetails\n1.0.0\n0\n[a-z0-9]{10}\nnull\n"
     }
 
-    def 'version includes tag if includePrefix is true' () {
-        given:
-        buildFile << '''
-            plugins {
-                id 'com.palantir.git-version'
-            }
-            version gitVersion(prefix:"my-product", includePrefix:true)
-            task printVersionDetails() << {
-                println versionDetails(prefix:"my-product", includePrefix:true).lastTag
-            }
-        '''.stripIndent()
-        gitIgnoreFile << 'build'
-        Git git = Git.init().setDirectory(projectDir).call();
-        git.add().addFilepattern('.').call()
-        git.commit().setMessage('initial commit').call()
-        git.tag().setAnnotated(true).setMessage('my-product1.0.0').setName('my-product1.0.0').call()
-
-        when:
-        BuildResult buildResult = with('printVersionDetails').build()
-
-        then:
-        buildResult.output =~ ":printVersionDetails\nmy-product1.0.0\n"
-    }
-
-    def 'version filters out tags not matching prefix' () {
+    def 'version filters out tags not matching prefix and strips prefix' () {
         given:
         buildFile << '''
             plugins {

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -15,18 +15,16 @@
  */
 package com.palantir.gradle.gitversion
 
+import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.MergeCommand
 import org.eclipse.jgit.lib.Ref
-
-import java.nio.file.Files
-
-import org.eclipse.jgit.api.Git
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
-
 import spock.lang.Specification
+
+import java.nio.file.Files
 
 class GitVersionPluginTests extends Specification {
     @Rule
@@ -422,16 +420,16 @@ class GitVersionPluginTests extends Specification {
             plugins {
                 id 'com.palantir.git-version'
             }
-            version gitVersion(prefix:"my-product")
+            version gitVersion(prefix:"my-product@")
             task printVersionDetails() << {
-                println versionDetails(prefix:"my-product").lastTag
+                println versionDetails(prefix:"my-product@").lastTag
             }
         '''.stripIndent()
         gitIgnoreFile << 'build'
         Git git = Git.init().setDirectory(projectDir).call();
         git.add().addFilepattern('.').call()
         git.commit().setMessage('initial commit').call()
-        git.tag().setAnnotated(true).setMessage('my-product1.0.0').setName('my-product1.0.0').call()
+        git.tag().setAnnotated(true).setMessage('my-product@1.0.0').setName('my-product@1.0.0').call()
         git.commit().setMessage('commit 2').call()
         git.tag().setAnnotated(true).setMessage('1.1.0').setName('1.1.0').call()
 
@@ -440,6 +438,27 @@ class GitVersionPluginTests extends Specification {
 
         then:
         buildResult.output =~ ":printVersionDetails\n1.0.0\n"
+    }
+
+    def 'test valid prefixes' () {
+        expect:
+        GitVersionPlugin.verifyPrefix("@Product@")
+        GitVersionPlugin.verifyPrefix("abc@")
+        GitVersionPlugin.verifyPrefix("abc@test@")
+        GitVersionPlugin.verifyPrefix("Abc-aBc-abC@")
+        GitVersionPlugin.verifyPrefix("foo-bar@")
+        GitVersionPlugin.verifyPrefix("foo-bar/")
+        GitVersionPlugin.verifyPrefix("foo-bar-")
+        GitVersionPlugin.verifyPrefix("foo/bar@")
+        GitVersionPlugin.verifyPrefix("Foo/Bar@")
+    }
+
+    def 'test requires @ or / or - between prefix and version' () {
+        when:
+        GitVersionPlugin.verifyPrefix("v")
+
+        then:
+        thrown AssertionError
     }
 
     private GradleRunner with(String... tasks) {


### PR DESCRIPTION
gitVersionOpt is added which allows for configuration of prefix and
includePrefix. By specifying a prefix, only tags including that prefix
will be searched. If includePrefix is by default false, which means that
it will be stripped from the output version. e.g. v0.10.0 -> 0.10.0