### PR TITLE
Add non-abbreviated GitHash as gitHashFull

### DIFF
--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
@@ -64,10 +64,11 @@ class GitVersionPlugin implements Plugin<Project> {
         verifyPrefix(args.prefix)
         String description = stripPrefix(gitDescribe(project, args.prefix), args.prefix)
         String hash = gitHash(project)
+        String fullHash = gitHashFull(project)
         String branchName = gitBranchName(project)
         boolean isClean = isClean(project)
 
-        return new VersionDetails(description, hash, branchName, isClean)
+        return new VersionDetails(description, hash, fullHash, branchName, isClean)
     }
 
     @Memoized
@@ -102,6 +103,16 @@ class GitVersionPlugin implements Plugin<Project> {
             return null
         }
         return objectId.abbreviate(VERSION_ABBR_LENGTH).name()
+    }
+
+    @Memoized
+    private String gitHashFull(Project project) {
+        Git git = gitRepo(project)
+        ObjectId objectId = git.getRepository().getRef("HEAD").getObjectId();
+        if (objectId == null) {
+            return null
+        }
+        return objectId.name()
     }
 
     @Memoized

--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
@@ -97,12 +97,11 @@ class GitVersionPlugin implements Plugin<Project> {
 
     @Memoized
     private String gitHash(Project project) {
-        Git git = gitRepo(project)
-        ObjectId objectId = git.getRepository().getRef("HEAD").getObjectId();
-        if (objectId == null) {
+        String gitHashFull = gitHashFull(project)
+        if (gitHashFull == null) {
             return null
         }
-        return objectId.abbreviate(VERSION_ABBR_LENGTH).name()
+        return gitHashFull.substring(0, VERSION_ABBR_LENGTH)
     }
 
     @Memoized

--- a/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
@@ -29,12 +29,14 @@ class VersionDetails implements Serializable {
 
     final String description;
     final String gitHash;
+    final String gitHashFull;
     final String branchName;
     final boolean isClean;
 
-    public VersionDetails(String description, String gitHash, String branchName, boolean isClean) {
+    public VersionDetails(String description, String gitHash, String gitHashFull, String branchName, boolean isClean) {
         this.description = description;
         this.gitHash = gitHash;
+        this.gitHashFull = gitHashFull;
         this.branchName = branchName;
         this.isClean = isClean;
     }

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -298,7 +298,7 @@ class GitVersionPluginTests extends Specification {
         BuildResult buildResult = with('printVersionDetails').build()
 
         then:
-        buildResult.output.contains(':printVersionDetails\ncom.palantir.gradle.gitversion.VersionDetails(null, null, null, false)\n')
+        buildResult.output.contains(':printVersionDetails\ncom.palantir.gradle.gitversion.VersionDetails(null, null, null, null, false)\n')
     }
 
     def 'version details on commit with a tag' () {
@@ -312,6 +312,7 @@ class GitVersionPluginTests extends Specification {
                 println versionDetails().lastTag
                 println versionDetails().commitDistance
                 println versionDetails().gitHash
+                println versionDetails().gitHashFull
                 println versionDetails().branchName
                 println versionDetails().isCleanTag
             }
@@ -326,7 +327,7 @@ class GitVersionPluginTests extends Specification {
         BuildResult buildResult = with('printVersionDetails').build()
 
         then:
-        buildResult.output =~ ":printVersionDetails\n1.0.0\n0\n[a-z0-9]{10}\nmaster\ntrue\n"
+        buildResult.output =~ ":printVersionDetails\n1.0.0\n0\n[a-z0-9]{10}\n[a-z0-9]{40}\nmaster\ntrue\n"
     }
 
     def 'version details when commit distance to tag is > 0' () {


### PR DESCRIPTION
* Adds `versionDetails().gitHashFull` to return the 40-character git hash.  This is a backwards-compatible change.
* Adds `gitFullHash` to constructor for `VersionDetails`.  _If_ `VersionDetails` is part of the public API, then this would be a backwards-_incompatible_ change
* Did _not_ update the README because this feature would need to be part of a release before it is available to users
* Closes #67