### PR TITLE
Update the readme to document gitHashFull

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ def details = versionDetails()
 details.lastTag
 details.commitDistance
 details.gitHash
+details.gitHashFull // new in 0.9.0 - full 40-character git hash
 details.branchName // is null if the repository in detached HEAD mode
 details.isCleanTag
 ```

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ def details = versionDetails()
 details.lastTag
 details.commitDistance
 details.gitHash
-details.gitHashFull // new in 0.9.0 - full 40-character git hash
+details.gitHashFull // full 40-character Git commit hash
 details.branchName // is null if the repository in detached HEAD mode
 details.isCleanTag
 ```


### PR DESCRIPTION
After merging #68 and the release of 0.9.0, we can document `versionDetails().gitHashFull`