### PR TITLE
Allow forcing snapshot version

### DIFF
--- a/src/main/groovy/com/palantir/gradle/gitversion/GitCli.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitCli.groovy
@@ -15,8 +15,14 @@
  */
 package com.palantir.gradle.gitversion
 
+import org.gradle.api.Project
+
 class GitCli {
-    private GitCli() {}
+    private final Project project
+
+    GitCli(Project project) {
+        this.project = project
+    }
 
     static void verifyGitCommandExists() {
         Process gitVersionProcess = new ProcessBuilder("git", "version").start()
@@ -25,13 +31,13 @@ class GitCli {
         }
     }
 
-    static String runGitCommand(File dir, String... commands) {
-        List<String> cmdInput = new ArrayList<>()
-        cmdInput.add("git")
-        cmdInput.addAll(commands)
+    String runGitCommand(File dir, String... commands) {
+        def cmdInput = ["git"] + commands.toList()
         ProcessBuilder pb = new ProcessBuilder(cmdInput)
         pb.directory(dir)
         pb.redirectErrorStream(true)
+
+        project.logger.info("Running git command: $cmdInput")
 
         Process process = pb.start()
         BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))
@@ -45,6 +51,7 @@ class GitCli {
 
         int exitCode = process.waitFor()
         if (exitCode != 0) {
+            project.logger.warn("Git command $commands failed ($exitCode) with output: $builder")
             return ""
         }
 

--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionArgs.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionArgs.groovy
@@ -2,4 +2,8 @@ package com.palantir.gradle.gitversion
 
 class GitVersionArgs {
     String prefix = ''
+    /**
+     * If we're currently on a tag (or more), exclude them from git-describe so we always get a snapshot version.
+     */
+    boolean forceSnapshot = false
 }

--- a/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/VersionDetails.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.palantir.gradle.gitversion;
+package com.palantir.gradle.gitversion
 
 import groovy.transform.*
 
@@ -25,23 +25,23 @@ class VersionDetails implements Serializable {
 
     // Gradle returns 'unspecified' when no version is set
     private static final String UNSPECIFIED_VERSION = 'unspecified'
-    private static final long serialVersionUID = -7340444937169877612L;
+    private static final long serialVersionUID = -7340444937169877612L
 
-    final String description;
-    final String gitHash;
-    final String gitHashFull;
-    final String branchName;
-    final boolean isClean;
+    final String description
+    final String gitHash
+    final String gitHashFull
+    final String branchName
+    final boolean isClean
 
-    public VersionDetails(String description, String gitHash, String gitHashFull, String branchName, boolean isClean) {
-        this.description = description;
-        this.gitHash = gitHash;
-        this.gitHashFull = gitHashFull;
-        this.branchName = branchName;
-        this.isClean = isClean;
+    VersionDetails(String description, String gitHash, String gitHashFull, String branchName, boolean isClean) {
+        this.description = description
+        this.gitHash = gitHash
+        this.gitHashFull = gitHashFull
+        this.branchName = branchName
+        this.isClean = isClean
     }
 
-    public String getVersion() {
+    String getVersion() {
         if (description == null) {
             return UNSPECIFIED_VERSION
         }
@@ -49,31 +49,31 @@ class VersionDetails implements Serializable {
         return description + (isClean ? '' : '.dirty')
     }
 
-    public boolean getIsCleanTag() {
-        return isClean && descriptionIsPlainTag();
+    boolean getIsCleanTag() {
+        return isClean && descriptionIsPlainTag()
     }
 
-    public int getCommitDistance() {
+    int getCommitDistance() {
         if (descriptionIsPlainTag()) {
-            return 0;
+            return 0
         }
 
         Matcher match = (description =~ /(.*)-([0-9]+)-g.?[0-9a-fA-F]{3,}/)
         int commitCount = Integer.valueOf(match[0][2])
-        return commitCount;
+        return commitCount
     }
 
-    public String getLastTag() {
+    String getLastTag() {
         if (descriptionIsPlainTag()) {
-            return description;
+            return description
         }
 
         Matcher match = (description =~ /(.*)-([0-9]+)-g.?[0-9a-fA-F]{3,}/)
         String tagName = match[0][1]
-        return tagName;
+        return tagName
     }
 
     private boolean descriptionIsPlainTag() {
-        return !(description =~ /.*g.?[0-9a-fA-F]{3,}/);
+        return !(description =~ /.*g.?[0-9a-fA-F]{3,}/)
     }
 }

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -343,6 +343,7 @@ class GitVersionPluginTests extends Specification {
                 println details.gitHash
                 println details.gitHashFull
                 println details.branchName
+                println details.isClean
                 println details.isCleanTag
             }
         '''.stripIndent()
@@ -366,7 +367,8 @@ class GitVersionPluginTests extends Specification {
                 "[a-z0-9]{10}\n" +
                 "[a-z0-9]{40}\n" +
                 "master\n" +
-                "true\n"
+                "true\n" +
+                "false"
     }
 
 

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -330,6 +330,46 @@ class GitVersionPluginTests extends Specification {
         buildResult.output =~ ":printVersionDetails\n1.0.0\n0\n[a-z0-9]{10}\n[a-z0-9]{40}\nmaster\ntrue\n"
     }
 
+    def 'version details on commit with two tags when forceSnapshot=true' () {
+        given:
+        buildFile << '''
+            plugins {
+                id 'com.palantir.git-version'
+            }
+            task printVersionDetails() << {
+                def details = versionDetails(forceSnapshot: true)
+                println details.lastTag
+                println details.commitDistance
+                println details.gitHash
+                println details.gitHashFull
+                println details.branchName
+                println details.isCleanTag
+            }
+        '''.stripIndent()
+        gitIgnoreFile << 'build'
+        Git git = Git.init().setDirectory(projectDir).call()
+        git.add().addFilepattern('.').call()
+        git.commit().setMessage('initial commit').call()
+        git.tag().setName('0.1.0').call()
+
+        git.commit().setAllowEmpty(true).setMessage('second commit').call()
+        git.tag().setAnnotated(true).setMessage('1.0.0').setName('1.0.0').call()
+        git.tag().setAnnotated(true).setMessage('1.0.1').setName('1.0.1').call()
+
+        when:
+        BuildResult buildResult = with('printVersionDetails').build()
+
+        then:
+        buildResult.output =~ ":printVersionDetails\n" +
+                "0.1.0-1-[a-z0-9]{7}\n" +
+                "1\n" +
+                "[a-z0-9]{10}\n" +
+                "[a-z0-9]{40}\n" +
+                "master\n" +
+                "true\n"
+    }
+
+
     def 'version details when commit distance to tag is > 0' () {
         given:
         buildFile << '''

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -361,7 +361,7 @@ class GitVersionPluginTests extends Specification {
 
         then:
         buildResult.output =~ ":printVersionDetails\n" +
-                "0.1.0-1-[a-z0-9]{7}\n" +
+                "0.1.0\n" +
                 "1\n" +
                 "[a-z0-9]{10}\n" +
                 "[a-z0-9]{40}\n" +


### PR DESCRIPTION
When you pass `forceSnapshot: true` to `versionDetails` or `gitVersion`, if HEAD points to a tag (or more), exclude these tags from git-describe's algorithm.