### PR TITLE
gitVersion() calls underlying C git, not JGit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,8 +5,8 @@ Git-Version Gradle Plugin
 
 When applied, Git-Version adds two methods to the target project.
 
-The first, called `gitVersion()`, runs the JGit equivalent of `git describe` to determine a version string.
-It behaves exactly as the JGit `git describe` method behaves, except that when the repository is in a dirty
+The first, called `gitVersion()`, runs `git describe` to determine a version string.
+It behaves exactly as `git describe` method behaves, except that when the repository is in a dirty
 state, appends `.dirty` to the version string.
 
 The second, called `versionDetails()`, returns an object containing the specific details of the version string:


### PR DESCRIPTION
Since https://github.com/palantir/gradle-git-version/commit/4654a72df7a328cba71f4644f7fbf34fa23dc23b