### PR TITLE
Use rev-list --first-parent to support git < 1.8.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ repositories {
 dependencies {
     compile gradleApi()
     compile 'org.eclipse.jgit:org.eclipse.jgit:4.5.2.201704071617-r'
+    compile 'com.google.guava:guava:23.0'
 
     testCompile gradleTestKit()
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
 dependencies {
     compile gradleApi()
     compile 'org.eclipse.jgit:org.eclipse.jgit:4.5.2.201704071617-r'
-    compile 'com.google.guava:guava:23.0'
+    compile 'com.google.guava:guava:20.0'
 
     testCompile gradleTestKit()
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {


### PR DESCRIPTION
Current implementation uses --first-parent for git describe, a feature only added in Git 1.8.4. This change uses rev-list instead to walk the commit history and format the version string.

Tested with Git versions 1.7.1 and 2.11.1