### PR TITLE
Fix wrong commit sha in version

### DIFF
--- a/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/gitversion/GitVersionPlugin.groovy
@@ -117,7 +117,8 @@ class GitVersionPlugin implements Plugin<Project> {
                 if (tagRefs.contains(rev)) {
                     String exactTag = runGitCmd("describe", "--tags", "--exact-match", "--match=${prefix}*", rev)
                     if (exactTag != "") {
-                        return depth == 0 ? exactTag : String.format("%s-%s-g%s", exactTag, depth, abbrevHash(rev))
+                        return depth == 0 ?
+                                exactTag : String.format("%s-%s-g%s", exactTag, depth, abbrevHash(revs.get(0)))
                     }
                 }
             }

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -160,7 +160,7 @@ class GitVersionPluginTests extends Specification {
         buildResult.output.contains(":printVersion\n1.0.0\n")
     }
 
-    def 'git describe when unannotated tag is present' () {
+    def 'git describe when lightweight tag is present' () {
         given:
         buildFile << '''
             plugins {
@@ -489,7 +489,7 @@ class GitVersionPluginTests extends Specification {
         buildResult.output.contains(":printVersion\n1.0.0-1-g${commitSha.substring(0, 7)}\n")
     }
 
-    def 'git describe with commit after unannotated tag' () {
+    def 'git describe with commit after lightweight tag' () {
         given:
         buildFile << '''
             plugins {

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -18,6 +18,7 @@ package com.palantir.gradle.gitversion
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.MergeCommand
 import org.eclipse.jgit.lib.Ref
+import org.eclipse.jgit.revwalk.RevCommit
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
@@ -457,11 +458,11 @@ class GitVersionPluginTests extends Specification {
         git.tag().setAnnotated(true).setMessage('1.0.0').setName('1.0.0').call()
         dirtyContentFile << 'dirty-content'
         git.add().addFilepattern('.').call()
-        git.commit().setMessage('added some stuff').call()
+        RevCommit latestCommit = git.commit().setMessage('added some stuff').call()
 
         when:
         BuildResult buildResult = with('printVersion').build()
-        String commitSha = (++git.log().call().iterator()).getName()
+        String commitSha = latestCommit.getName()
 
         then:
         buildResult.output.contains(":printVersion\n1.0.0-1-g${commitSha.substring(0, 7)}\n")


### PR DESCRIPTION
Current implementation has a bug, in that the abbreviated hash is that of the latest tag instead of the latest commit. This fixes the issue and also includes a test.