### PR TITLE
Use 'extraProperties' instead of a normal extension

### DIFF
--- a/src/main/java/com/palantir/gradle/gitversion/GitVersionPlugin.java
+++ b/src/main/java/com/palantir/gradle/gitversion/GitVersionPlugin.java
@@ -17,13 +17,15 @@ import java.io.IOException;
 
 public class GitVersionPlugin implements Plugin<Project> {
     public void apply(final Project project) {
-        project.getExtensions().add("gitVersion", new Closure<String>(this, this) {
+
+        // intentionally not using .getExtension() here for back-compat
+        project.getExtensions().getExtraProperties().set("gitVersion", new Closure<String>(this, this) {
             public String doCall(Object args) {
                 return versionDetails(project, GitVersionArgs.fromGroovyClosure(args)).getVersion();
             }
         });
 
-        project.getExtensions().add("versionDetails", new Closure<VersionDetails>(this, this) {
+        project.getExtensions().getExtraProperties().set("versionDetails", new Closure<VersionDetails>(this, this) {
             public VersionDetails doCall(Object args) {
                 return versionDetails(project, GitVersionArgs.fromGroovyClosure(args));
             }

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -354,6 +354,30 @@ class GitVersionPluginTests extends Specification {
         buildResult.output =~ ":printVersionDetails\n1.0.0\n0\n[a-z0-9]{10}\n[a-z0-9]{40}\nmaster\ntrue\n"
     }
 
+    def 'version details can be accessed using extra properties method' () {
+        given:
+        buildFile << '''
+            plugins {
+                id 'com.palantir.git-version'
+            }
+            version gitVersion()
+            task printVersionDetails() << {
+                println project.getExtensions().getExtraProperties().get('versionDetails')().lastTag
+                println project.getExtensions().getExtraProperties().get('gitVersion')()
+            }
+        '''.stripIndent()
+        gitIgnoreFile << 'build'
+        Git git = Git.init().setDirectory(projectDir).call();
+        git.add().addFilepattern('.').call()
+        String sha = git.commit().setMessage('initial commit').call().getName().subSequence(0, 7)
+
+        when:
+        BuildResult buildResult = with('printVersionDetails').build()
+
+        then:
+        buildResult.output =~ ":printVersionDetails\n${sha}\n${sha}\n"
+    }
+
     def 'version details when commit distance to tag is > 0' () {
         given:
         buildFile << '''


### PR DESCRIPTION
Internal usage is relying on this strange way of accessing the `versionDetails` class :(