### PR TITLE
Upgrade jgit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile 'org.eclipse.jgit:org.eclipse.jgit:4.5.2.201704071617-r'
+    compile 'org.eclipse.jgit:org.eclipse.jgit:4.5.4.201711221230-r'
     compile 'com.google.guava:guava:20.0'
 
     testCompile gradleTestKit()


### PR DESCRIPTION
Note this isn't latest jgit because it requires a java8 compiler.

Apparently some bugs were fixed: https://bugs.eclipse.org/bugs/buglist.cgi?classification=Technology&list_id=10006180&order=Importance&product=JGit&query_format=advanced&resolution=FIXED&resolution=DUPLICATE&target_milestone=4.5