### PR TITLE
Catch missing object exception

### DIFF
--- a/src/main/java/com/palantir/gradle/gitversion/JGitDescribe.java
+++ b/src/main/java/com/palantir/gradle/gitversion/JGitDescribe.java
@@ -1,6 +1,7 @@
 package com.palantir.gradle.gitversion;
 
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.errors.MissingObjectException;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
@@ -75,7 +76,12 @@ class JGitDescribe implements GitDescribe {
                     break;
                 }
 
-                head = walk.parseCommit(parents[0]);
+                try {
+                    head = walk.parseCommit(parents[0]);
+                } catch (MissingObjectException e) {
+                    log.debug("First parent object missing: {}", e);
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Fix #98 

When doing shallow clone, we're not able to walk the whole tree. We shouldn't fail with exception, we should try to get tag on the part we're able to walk.