### PR TITLE
[improvement] Cache result of git calls

### DIFF
--- a/src/main/java/com/palantir/gradle/gitversion/GitVersionArgs.java
+++ b/src/main/java/com/palantir/gradle/gitversion/GitVersionArgs.java
@@ -3,6 +3,7 @@ package com.palantir.gradle.gitversion;
 import com.google.common.base.Preconditions;
 
 import java.util.Map;
+import java.util.Objects;
 
 class GitVersionArgs {
     private static final String PREFIX_REGEX = "[/@]?([A-Za-z]+[/@-])+";
@@ -20,6 +21,23 @@ class GitVersionArgs {
                 "Specified prefix `" + prefix + "` does not match the allowed format regex `" + PREFIX_REGEX + "`.");
 
         this.prefix = prefix;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        GitVersionArgs that = (GitVersionArgs) other;
+        return Objects.equals(prefix, that.prefix);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(prefix);
     }
 
     // groovy closure invocation allows any number of args

--- a/src/main/java/com/palantir/gradle/gitversion/GitVersionPlugin.java
+++ b/src/main/java/com/palantir/gradle/gitversion/GitVersionPlugin.java
@@ -1,6 +1,11 @@
 package com.palantir.gradle.gitversion;
 
 import groovy.lang.Closure;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.gradle.api.Action;
@@ -8,24 +13,20 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 
-import java.io.File;
-import java.io.IOException;
-
 public class GitVersionPlugin implements Plugin<Project> {
-    public void apply(final Project project) {
+    private final Map<GitVersionArgs, Map<File, VersionDetails>> cachedVersionDetails = new HashMap<>();
 
+    public void apply(final Project project) {
         // intentionally not using .getExtension() here for back-compat
         project.getExtensions().getExtraProperties().set("gitVersion", new Closure<String>(this, this) {
             public String doCall(Object args) {
-                Git git = gitRepo(project);
-                return new VersionDetails(git, GitVersionArgs.fromGroovyClosure(args)).getVersion();
+                return getVersionDetails(project, GitVersionArgs.fromGroovyClosure(args)).getVersion();
             }
         });
 
         project.getExtensions().getExtraProperties().set("versionDetails", new Closure<VersionDetails>(this, this) {
             public VersionDetails doCall(Object args) {
-                Git git = gitRepo(project);
-                return new VersionDetails(git, GitVersionArgs.fromGroovyClosure(args));
+                return getVersionDetails(project, GitVersionArgs.fromGroovyClosure(args));
             }
         });
 
@@ -40,9 +41,26 @@ public class GitVersionPlugin implements Plugin<Project> {
         printVersionTask.setDescription("Prints the project's configured version to standard out");
     }
 
-    private static Git gitRepo(Project project) {
+    /**
+     * Fetch a cached version of VersionDetails.
+     */
+    private synchronized VersionDetails getVersionDetails(Project project, GitVersionArgs versionArgs) {
+        if (!cachedVersionDetails.containsKey(versionArgs)) {
+            cachedVersionDetails.put(versionArgs, new HashMap<File, VersionDetails>());
+        }
+        Map<File, VersionDetails> versionArgCache = cachedVersionDetails.get(versionArgs);
+        File rootGitDir = getRootGitDir(project.getProjectDir());
+
+        if (!versionArgCache.containsKey(rootGitDir)) {
+            versionArgCache.put(rootGitDir, new VersionDetails(gitRepo(rootGitDir), versionArgs));
+        }
+
+        return versionArgCache.get(rootGitDir);
+    }
+
+    private static Git gitRepo(File dir) {
         try {
-            File gitDir = getRootGitDir(project.getProjectDir());
+            File gitDir = getRootGitDir(dir);
             return Git.wrap(new FileRepository(gitDir));
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

Fixes #106

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
Git calls aren't cached.

## After this PR
<!-- Describe at a high-level why this approach is better. -->
Git call results are cached, improving build speeds in multi-project setups even when using the plugin naively.

The cache is both version arg & git root aware, so will handle e.g. different prefixes/git roots being used in a single build.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
