### PR TITLE
[improvement] Allow publishing x.y.0 tags using long descriptions

### DIFF
--- a/src/main/java/com/palantir/gradle/gitversion/GitVersionArgs.java
+++ b/src/main/java/com/palantir/gradle/gitversion/GitVersionArgs.java
@@ -1,16 +1,21 @@
 package com.palantir.gradle.gitversion;
 
-import com.google.common.base.Preconditions;
-
 import java.util.Map;
+
+import com.google.common.base.Preconditions;
 
 class GitVersionArgs {
     private static final String PREFIX_REGEX = "[/@]?([A-Za-z]+[/@-])+";
 
     private String prefix = "";
+    private ReleasingModel model = ReleasingModel.DEVELOP;
 
     public String getPrefix() {
         return prefix;
+    }
+
+    public ReleasingModel getModel() {
+        return model;
     }
 
     public void setPrefix(String prefix) {
@@ -22,11 +27,24 @@ class GitVersionArgs {
         this.prefix = prefix;
     }
 
+    public void setModel(String model) {
+        Preconditions.checkNotNull(model, "model must not be null");
+        this.model = ReleasingModel.valueOf(model);
+    }
+
     // groovy closure invocation allows any number of args
     static GitVersionArgs fromGroovyClosure(Object... objects) {
         if (objects != null && objects.length > 0 && objects[0] instanceof Map) {
             GitVersionArgs instance = new GitVersionArgs();
-            instance.setPrefix(((Map) objects[0]).get("prefix").toString());
+            Map object = (Map) objects[0];
+            Object prefix = object.get("prefix");
+            if (prefix != null) {
+                instance.setPrefix(prefix.toString());
+            }
+            Object model = object.get("model");
+            if (model != null) {
+                instance.setModel(model.toString());
+            }
             return instance;
         }
 

--- a/src/main/java/com/palantir/gradle/gitversion/ReleasingModel.java
+++ b/src/main/java/com/palantir/gradle/gitversion/ReleasingModel.java
@@ -1,0 +1,26 @@
+package com.palantir.gradle.gitversion;
+
+public enum ReleasingModel {
+    /**
+     * Indicates that releases are produced from develop. Tags
+     * will all produce versions that match the tag.
+     *
+     * For example, tag 1.0.0 will produce a version 1.0.0.
+     */
+    DEVELOP,
+
+    /**
+     * Indicates that releases are produced from release branches.
+     * Tags that match \d+\.\d+\.0 will produce versions using
+     * <pre>git describe --long</pre>
+     *
+     * For example:
+     *  - tag 1.0.0 will produce a version 1.0.0-0-g{hash}
+     *  - tag 1.0.1 will produce a version 1.0.1
+     *
+     * This allows the develop/main branch to include x.y.0 tags
+     * that aren't published as "releases", but instead published
+     * as develop snapshots.
+     */
+    RELEASE_BRANCH
+}

--- a/src/main/java/com/palantir/gradle/gitversion/VersionDetails.java
+++ b/src/main/java/com/palantir/gradle/gitversion/VersionDetails.java
@@ -1,5 +1,9 @@
 package com.palantir.gradle.gitversion;
 
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Constants;
@@ -7,10 +11,6 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public final class VersionDetails {
 
@@ -59,7 +59,7 @@ public final class VersionDetails {
             return null;
         }
 
-        return new JGitDescribe(git).describe(args.getPrefix());
+        return new JGitDescribe(git, args.getModel()).describe(args.getPrefix());
     }
 
     private boolean isRepoEmpty() {

--- a/src/test/java/com/palantir/gradle/gitversion/JGitDescribeTest.java
+++ b/src/test/java/com/palantir/gradle/gitversion/JGitDescribeTest.java
@@ -1,15 +1,6 @@
 package com.palantir.gradle.gitversion;
 
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.MergeCommand;
-import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.lib.PersonIdent;
-import org.eclipse.jgit.lib.Ref;
-import org.eclipse.jgit.revwalk.RevCommit;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -20,7 +11,16 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.MergeCommand;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class JGitDescribeTest {
 
@@ -44,6 +44,17 @@ public class JGitDescribeTest {
         git.tag().setAnnotated(true).setMessage("1.0.0").setName("1.0.0").call();
 
         assertThat(jgitDescribe()).isEqualTo(nativeGitDescribe());
+        assertThat(jgitDescribe(ReleasingModel.RELEASE_BRANCH)).isEqualTo(nativeGitDescribeLong());
+    }
+
+    @Test
+    public void test_on_annotated_tag_2() throws Exception {
+        git.add().addFilepattern(".").call();
+        git.commit().setMessage("initial commit").call();
+        git.tag().setAnnotated(true).setMessage("1.0.1").setName("1.0.1").call();
+
+        assertThat(jgitDescribe()).isEqualTo(nativeGitDescribe());
+        assertThat(jgitDescribe(ReleasingModel.RELEASE_BRANCH)).isEqualTo(nativeGitDescribe());
     }
 
     @Test
@@ -53,6 +64,7 @@ public class JGitDescribeTest {
         git.tag().setAnnotated(false).setName("1.0.0").call();
 
         assertThat(jgitDescribe()).isEqualTo(nativeGitDescribe());
+        assertThat(jgitDescribe(ReleasingModel.RELEASE_BRANCH)).isEqualTo(nativeGitDescribeLong());
     }
 
     @Test
@@ -70,6 +82,7 @@ public class JGitDescribeTest {
                 .setFastForward(MergeCommand.FastForwardMode.NO_FF).setMessage("merge commit").call();
 
         assertThat(jgitDescribe()).isEqualTo(nativeGitDescribe());
+        assertThat(jgitDescribe(ReleasingModel.RELEASE_BRANCH)).isEqualTo(nativeGitDescribeLong());
     }
 
     @Test
@@ -88,6 +101,7 @@ public class JGitDescribeTest {
         git.tag().setAnnotated(true).setMessage("2.0.0").setName("2.0.0").call();
 
         assertThat(jgitDescribe()).isEqualTo(nativeGitDescribe());
+        assertThat(jgitDescribe(ReleasingModel.RELEASE_BRANCH)).isEqualTo(nativeGitDescribeLong());
     }
 
     @Test
@@ -99,6 +113,7 @@ public class JGitDescribeTest {
         git.checkout().setName(commit1.getId().getName()).call();
 
         assertThat(jgitDescribe()).isEqualTo(nativeGitDescribe());
+        assertThat(jgitDescribe(ReleasingModel.RELEASE_BRANCH)).isEqualTo(nativeGitDescribeLong());
     }
 
     @Test
@@ -110,6 +125,7 @@ public class JGitDescribeTest {
         git.commit().setMessage("added some stuff").call();
 
         assertThat(jgitDescribe()).isEqualTo(nativeGitDescribe());
+        assertThat(jgitDescribe(ReleasingModel.RELEASE_BRANCH)).isEqualTo(nativeGitDescribeLong());
     }
 
     @Test
@@ -123,6 +139,7 @@ public class JGitDescribeTest {
         }
 
         assertThat(jgitDescribe()).isEqualTo(nativeGitDescribe());
+        assertThat(jgitDescribe(ReleasingModel.RELEASE_BRANCH)).isEqualTo(nativeGitDescribeLong());
     }
 
     @Test
@@ -134,6 +151,7 @@ public class JGitDescribeTest {
         git.commit().setMessage("added some stuff").call();
 
         assertThat(jgitDescribe()).isEqualTo(nativeGitDescribe());
+        assertThat(jgitDescribe(ReleasingModel.RELEASE_BRANCH)).isEqualTo(nativeGitDescribeLong());
     }
 
     @Test
@@ -147,6 +165,7 @@ public class JGitDescribeTest {
         }
 
         assertThat(jgitDescribe()).isEqualTo(nativeGitDescribe());
+        assertThat(jgitDescribe(ReleasingModel.RELEASE_BRANCH)).isEqualTo(nativeGitDescribeLong());
     }
 
     @Test
@@ -158,6 +177,7 @@ public class JGitDescribeTest {
         git.tag().setAnnotated(false).setName("3.0.0").call();
 
         assertThat(jgitDescribe()).isEqualTo(nativeGitDescribe());
+        assertThat(jgitDescribe(ReleasingModel.RELEASE_BRANCH)).isEqualTo(nativeGitDescribeLong());
     }
 
     @Test
@@ -172,6 +192,7 @@ public class JGitDescribeTest {
                 new PersonIdent(identity, new Date(0, 0, 5))).setName("3.0.0").call();
 
         assertThat(jgitDescribe()).isEqualTo(nativeGitDescribe());
+        assertThat(jgitDescribe(ReleasingModel.RELEASE_BRANCH)).isEqualTo(nativeGitDescribeLong());
     }
 
     @Test
@@ -183,14 +204,23 @@ public class JGitDescribeTest {
         git.tag().setAnnotated(false).setName("3.0.0").call();
 
         assertThat(jgitDescribe()).isEqualTo(nativeGitDescribe());
+        assertThat(jgitDescribe(ReleasingModel.RELEASE_BRANCH)).isEqualTo(nativeGitDescribeLong());
     }
 
     private String jgitDescribe() throws GitAPIException {
-        return new JGitDescribe(git).describe("");
+        return new JGitDescribe(git, ReleasingModel.DEVELOP).describe("");
+    }
+
+    private String jgitDescribe(ReleasingModel model) throws GitAPIException {
+        return new JGitDescribe(git, model).describe("");
     }
 
     private String nativeGitDescribe() throws IOException, InterruptedException, RuntimeException {
         return runGitCmd(projectDir, "describe", "--tags", "--always", "--first-parent", "HEAD");
+    }
+
+    private String nativeGitDescribeLong() throws IOException, InterruptedException, RuntimeException {
+        return runGitCmd(projectDir, "describe", "--tags", "--always", "--long", "--first-parent", "HEAD");
     }
 
     private String runGitCmd(File directory, String... commands)


### PR DESCRIPTION
This allows repositories to tag x.y.0 on develop/main branch
without publishing those builds as releases. Instead, they
will publish as x.y.0-0-g{hash}.

For example:
```
  |
  |
  1.1.0
  |
  |     1.0.2
  |    /
  |  1.0.1
  | /
  |/
  |
  1.0.0
  |
```
The develop branch has tags 1.1.0 and 1.0.0, but these
are published as 1.0.0-0-g{hash} and 1.1.0-0-g{hash}. The
release/1.0.x branch has tags 1.0.1, 1.0.2 that are published
as expected.
Untagged develop commits look like snapshots, as expected. For example,
the commits following 1.0.0 tag will look like 1.0.0-1-g{hash},
1.0.0-2-g{hash}, etc.
This allows customers to follow all versions matching x.y.z release
format without picking up any develop commits, while also allowing
develop commits to be semantically ahead of release branches.

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->

## After this PR
<!-- Describe at a high-level why this approach is better. -->

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
