### PR TITLE
Fix publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,14 @@ buildscript {
     repositories {
         maven { url "http://palantir.bintray.com/releases" }
     }
+    dependencies {
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+        classpath 'com.netflix.nebula:nebula-publishing-plugin:13.2.0'
+    }
 }
 
 plugins {
     id 'com.gradle.plugin-publish' version '0.9.9'
-    id 'com.jfrog.bintray' version '1.8.4'
     id 'com.palantir.baseline' version '1.18.0'
     id 'com.palantir.git-version' version '0.11.0'
 }
@@ -15,7 +18,7 @@ apply plugin: 'com.palantir.baseline'
 apply plugin: 'groovy'
 apply plugin: 'java-gradle-plugin'
 apply plugin: 'java-library'
-apply plugin: 'maven-publish'
+apply from: "${rootDir}/gradle/publish-jar.gradle"
 
 group 'com.palantir.gradle.gitversion'
 version gitVersion()
@@ -46,45 +49,6 @@ tasks.withType(JavaCompile) {
     options.compilerArgs += ['-Werror', '-Xlint:deprecation']
 }
 
-
-task sourceJar(type: Jar) {
-    from sourceSets.main.allSource
-    classifier 'sources'
-}
-
-publishing {
-    publications {
-        bintray(MavenPublication) {
-            from components.java
-            artifact(sourceJar)
-            artifact(publishPluginJavaDocsJar)
-        }
-    }
-}
-
-tasks.publish {
-    dependsOn 'bintrayUpload', 'publishPlugins'
-}
-
-bintray {
-    user = System.env.BINTRAY_USER
-    key = System.env.BINTRAY_KEY
-    publish = true
-    pkg {
-        repo = 'releases'
-        name = 'gradle-git-version'
-        userOrg = 'palantir'
-        licenses = ['Apache-2.0']
-        publications = ['bintray']
-    }
-}
-
-bintrayUpload.dependsOn 'generatePomFileForBintrayPublication', 'sourceJar', 'build'
-
-bintrayUpload.onlyIf {
-    System.env.BINTRAY_USER && System.env.BINTRAY_KEY && System.env.CIRCLE_TAG
-}
-
 pluginBundle {
     website = 'https://github.com/palantir/gradle-git-version'
     vcsUrl = 'https://github.com/palantir/gradle-git-version'
@@ -99,7 +63,8 @@ pluginBundle {
     }
 }
 
-publishPlugins.onlyIf {
-    System.env.CIRCLE_TAG
-}
+// Configure the publishPlugins task
+tasks.publish.dependsOn publishPlugins
+project.ext.'gradle.publish.key' = System.env["GRADLE_KEY"]
+project.ext.'gradle.publish.secret' = System.env["GRADLE_SECRET"]
 

--- a/changelog/@unreleased/pr-160.v2.yml
+++ b/changelog/@unreleased/pr-160.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Correctly publish gradle-git-version as a gradle plugin
+  links:
+  - https://github.com/palantir/gradle-git-version/pull/160

--- a/gradle/publish-jar.gradle
+++ b/gradle/publish-jar.gradle
@@ -1,0 +1,66 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file is managed by the excavator 'consistent-publish-scripts' check, changes will be overwritten.
+apply plugin: 'com.jfrog.bintray'
+// Intentionally not applying nebula.maven-publish, but most of its constituent plugins,
+// because we do _not_ want nebula.maven-compile-only
+apply plugin: 'maven-publish'
+apply plugin: 'nebula.maven-nebula-publish'
+apply plugin: 'nebula.maven-base-publish'
+apply plugin: 'nebula.maven-developer'
+apply plugin: 'nebula.maven-manifest'
+apply plugin: 'nebula.info-scm'
+apply plugin: 'nebula.maven-scm'
+
+apply plugin: 'nebula.javadoc-jar'
+apply plugin: 'nebula.source-jar'
+
+jar {
+    manifest {
+        attributes("Implementation-Version" : project.version)
+    }
+}
+
+bintray {
+    user = System.env.BINTRAY_USERNAME
+    key = System.env.BINTRAY_PASSWORD
+    publish = true
+    pkg {
+        repo = 'releases'
+        name = 'gradle-git-version'
+        userOrg = 'palantir'
+        licenses = ['Apache-2.0']
+        publications = ['nebula']
+    }
+}
+
+publish.dependsOn bintrayUpload
+bintrayUpload.onlyIf {
+    versionDetails().isCleanTag
+}
+
+// See: https://docs.gradle.org/5.2/userguide/publishing_maven.html#publishing_maven:resolved_dependencies
+// This replaces nebula.maven-resolved-dependencies, which doesn't work with the 'com.gradle.plugin-publish' plugin
+publishing {
+    publications.withType(MavenPublication).configureEach {
+        versionMapping {
+            allVariants {
+                fromResolutionResult()
+            }
+        }
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Before this PR
We had failed to correctly publish `0.12.0` to gradle, preventing users using the plugin syntax to upgrade to latest

## After this PR
==COMMIT_MSG==
Correctly publish gradle-git-version as a gradle plugin
==COMMIT_MSG==

## Possible downsides?
N/A

