### PR TITLE
feat: added getLastCommitMessage method on VersionDetails

### DIFF
--- a/src/main/java/com/palantir/gradle/gitversion/VersionDetails.java
+++ b/src/main/java/com/palantir/gradle/gitversion/VersionDetails.java
@@ -29,6 +29,8 @@ public interface VersionDetails {
 
     int getCommitDistance();
 
+    String getLastCommitMessage() throws IOException;
+
     boolean getIsCleanTag();
 
     String getVersion();

--- a/src/main/java/com/palantir/gradle/gitversion/VersionDetailsImpl.java
+++ b/src/main/java/com/palantir/gradle/gitversion/VersionDetailsImpl.java
@@ -25,6 +25,8 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,6 +126,24 @@ final class VersionDetailsImpl implements VersionDetails {
         Matcher match = Pattern.compile("(.*)-([0-9]+)-g.?[0-9a-fA-F]{3,}").matcher(description());
         Preconditions.checkState(match.matches(), "Cannot get commit distance for description: '%s'", description());
         return Integer.parseInt(match.group(2));
+    }
+
+    @Override
+    public String getLastCommitMessage() throws IOException {
+        final ObjectId objectId = git.getRepository().findRef(Constants.HEAD).getObjectId();
+        if (objectId == null) {
+            return null;
+        }
+
+        final RevWalk walk = new RevWalk(git.getRepository());
+
+        try {
+            final RevCommit commit = walk.parseCommit(objectId);
+            return commit.getFullMessage();
+        } finally {
+            walk.dispose();
+            walk.close();
+        }
     }
 
     @Override

--- a/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
+++ b/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
@@ -87,6 +87,24 @@ public class VersionDetailsTest {
         assertThat(versionDetails().getVersion()).isEqualTo("6f0c7ed.dirty");
     }
 
+    @Test
+    public void last_commit_message_when_exists_more_than_one_commits() throws Exception {
+        git.add().addFilepattern(".").call();
+        git.commit()
+                .setAuthor(identity)
+                .setCommitter(identity)
+                .setMessage("first commit")
+                .call();
+
+        git.commit()
+                .setAuthor(identity)
+                .setCommitter(identity)
+                .setMessage("second commit")
+                .call();
+
+        assertThat(versionDetails().getLastCommitMessage()).isEqualTo("second commit");
+    }
+
     private File write(File file) throws IOException {
         Files.write(file.toPath(), "content".getBytes(StandardCharsets.UTF_8));
         return file;


### PR DESCRIPTION
## Before this PR
In this plugin not exists or I did not found some function that returns the last commit message and I need this on my workflow.

## After this PR
Added a method that returns the last commit message on VersionDetails

## Possible downsides?
I don't see downsides

