### PR TITLE
fix: allow tagging the same commit with multiple tags

### DIFF
--- a/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
+++ b/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
@@ -90,10 +90,10 @@ public class VersionDetailsTest {
 
     @Test
     public void find_correct_tag_using_prefix() throws GitAPIException {
-        final String PROJECT_A_PREFIX = "PROJECTA@";
-        final String PROJECT_A_VERSION = "1.0.0";
-        final String PROJECT_B_PREFIX = "PROJECTB@";
-        final String PROJECT_B_VERSION = "2.0.0";
+        final String PROJECTA_PREFIX = "PROJECTA@";
+        final String PROJECTA_VERSION = "1.0.0";
+        final String PROJECTB_PREFIX = "PROJECTB@";
+        final String PROJECTB_VERSION = "2.0.0";
 
         git.add().addFilepattern(".").call();
         git.commit()
@@ -104,15 +104,15 @@ public class VersionDetailsTest {
         // Tag the current commit with 2 tags.
         git.tag()
                 .setAnnotated(false)
-                .setName(PROJECT_A_PREFIX + PROJECT_A_VERSION)
+                .setName(PROJECTA_PREFIX + PROJECTA_VERSION)
                 .call();
         git.tag()
                 .setAnnotated(false)
-                .setName(PROJECT_B_PREFIX + PROJECT_B_VERSION)
+                .setName(PROJECTB_PREFIX + PROJECTB_VERSION)
                 .call();
 
-        assertThat(versionDetails(PROJECT_A_PREFIX).getVersion()).isEqualTo(PROJECT_A_VERSION);
-        assertThat(versionDetails(PROJECT_B_PREFIX).getVersion()).isEqualTo(PROJECT_B_VERSION);
+        assertThat(versionDetails(PROJECTA_PREFIX).getVersion()).isEqualTo(PROJECTA_VERSION);
+        assertThat(versionDetails(PROJECTB_PREFIX).getVersion()).isEqualTo(PROJECTB_VERSION);
     }
 
     private File write(File file) throws IOException {

--- a/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
+++ b/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
@@ -90,10 +90,10 @@ public class VersionDetailsTest {
 
     @Test
     public void find_correct_tag_using_prefix() throws GitAPIException {
-        final String PROJECTA_PREFIX = "PROJECTA@";
-        final String PROJECTA_VERSION = "1.0.0";
-        final String PROJECTB_PREFIX = "PROJECTB@";
-        final String PROJECTB_VERSION = "2.0.0";
+        final String projectAPrefix = "PROJECTA@";
+        final String projectAVersion = "1.0.0";
+        final String projectBPrefix = "PROJECTB@";
+        final String projectBVersion = "2.0.0";
 
         git.add().addFilepattern(".").call();
         git.commit()
@@ -102,17 +102,11 @@ public class VersionDetailsTest {
                 .setMessage("initial commit")
                 .call();
         // Tag the current commit with 2 tags.
-        git.tag()
-                .setAnnotated(false)
-                .setName(PROJECTA_PREFIX + PROJECTA_VERSION)
-                .call();
-        git.tag()
-                .setAnnotated(false)
-                .setName(PROJECTB_PREFIX + PROJECTB_VERSION)
-                .call();
+        git.tag().setAnnotated(false).setName(projectAPrefix + projectAVersion).call();
+        git.tag().setAnnotated(false).setName(projectBPrefix + projectBVersion).call();
 
-        assertThat(versionDetails(PROJECTA_PREFIX).getVersion()).isEqualTo(PROJECTA_VERSION);
-        assertThat(versionDetails(PROJECTB_PREFIX).getVersion()).isEqualTo(PROJECTB_VERSION);
+        assertThat(versionDetails(projectAPrefix).getVersion()).isEqualTo(projectAVersion);
+        assertThat(versionDetails(projectBPrefix).getVersion()).isEqualTo(projectBVersion);
     }
 
     private File write(File file) throws IOException {


### PR DESCRIPTION
Fixes "Inconsistent git describe" errors in case multiple tags with different prefixes reference the same commit.

When using prefixes the same commit might have different tags.

The jgit code did not take the prefix into account and stored tags in a map:
commit → tag

If multiple tags with different prefixes referenced the same commit only the last
tag was stored in this map.

This commit takes a prefix into account and ignores all tags which do not start
with the given prefix.
