### PR TITLE
allow digits and minus in tag prefixes

### DIFF
--- a/src/main/java/com/palantir/gradle/gitversion/GitVersionArgs.java
+++ b/src/main/java/com/palantir/gradle/gitversion/GitVersionArgs.java
@@ -17,10 +17,11 @@
 package com.palantir.gradle.gitversion;
 
 import com.google.common.base.Preconditions;
+
 import java.util.Map;
 
 class GitVersionArgs {
-    private static final String PREFIX_REGEX = "[/@]?([A-Za-z]+[/@-])+";
+    private static final String PREFIX_REGEX = "[/@]?([-A-Za-z0-9]+[/@-])+";
 
     private String prefix = "";
 

--- a/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
+++ b/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
@@ -90,10 +90,10 @@ public class VersionDetailsTest {
 
     @Test
     public void find_correct_tag_using_prefix() throws GitAPIException {
-        final String PROJECT_A_PREFIX = "PROJECTA@";
-        final String PROJECT_A_VERSION = "1.0.0";
-        final String PROJECT_B_PREFIX = "PROJECTB@";
-        final String PROJECT_B_VERSION = "2.0.0";
+        final String PROJECTA_PREFIX = "PROJECTA@";
+        final String PROJECTA_VERSION = "1.0.0";
+        final String PROJECTB_PREFIX = "PROJECTB@";
+        final String PROJECTB_VERSION = "2.0.0";
 
         git.add().addFilepattern(".").call();
         git.commit()
@@ -104,15 +104,15 @@ public class VersionDetailsTest {
         // Tag the current commit with 2 tags.
         git.tag()
                 .setAnnotated(false)
-                .setName(PROJECT_A_PREFIX + PROJECT_A_VERSION)
+                .setName(PROJECTA_PREFIX + PROJECTA_VERSION)
                 .call();
         git.tag()
                 .setAnnotated(false)
-                .setName(PROJECT_B_PREFIX + PROJECT_B_VERSION)
+                .setName(PROJECTB_PREFIX + PROJECTB_VERSION)
                 .call();
 
-        assertThat(versionDetails(PROJECT_A_PREFIX).getVersion()).isEqualTo(PROJECT_A_VERSION);
-        assertThat(versionDetails(PROJECT_B_PREFIX).getVersion()).isEqualTo(PROJECT_B_VERSION);
+        assertThat(versionDetails(PROJECTA_PREFIX).getVersion()).isEqualTo(PROJECTA_VERSION);
+        assertThat(versionDetails(PROJECTB_PREFIX).getVersion()).isEqualTo(PROJECTB_VERSION);
     }
 
     private File write(File file) throws IOException {

--- a/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
+++ b/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
@@ -115,6 +115,20 @@ public class VersionDetailsTest {
         assertThat(versionDetails(PROJECT_B_PREFIX).getVersion()).isEqualTo(PROJECT_B_VERSION);
     }
 
+    @Test
+    public void different_prefixes_are_allowed() throws GitAPIException {
+        git.add().addFilepattern(".").call();
+        git.commit()
+                .setAuthor(identity)
+                .setCommitter(identity)
+                .setMessage("initial commit")
+                .call();
+
+        // If these don't throw, we are fine:
+        assertThat(versionDetails("TagWithNumber1@").getVersion()).isEqualTo("6f0c7ed");
+        assertThat(versionDetails("TagWith-Minus@").getVersion()).isEqualTo("6f0c7ed");
+    }
+
     private File write(File file) throws IOException {
         Files.write(file.toPath(), "content".getBytes(StandardCharsets.UTF_8));
         return file;

--- a/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
+++ b/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
@@ -90,10 +90,10 @@ public class VersionDetailsTest {
 
     @Test
     public void find_correct_tag_using_prefix() throws GitAPIException {
-        final String PROJECTA_PREFIX = "PROJECTA@";
-        final String PROJECTA_VERSION = "1.0.0";
-        final String PROJECTB_PREFIX = "PROJECTB@";
-        final String PROJECTB_VERSION = "2.0.0";
+        final String projectAPrefix = "PROJECTA@";
+        final String projectAVersion = "1.0.0";
+        final String projectBPrefix = "PROJECTB@";
+        final String projectBVersion = "2.0.0";
 
         git.add().addFilepattern(".").call();
         git.commit()
@@ -102,17 +102,11 @@ public class VersionDetailsTest {
                 .setMessage("initial commit")
                 .call();
         // Tag the current commit with 2 tags.
-        git.tag()
-                .setAnnotated(false)
-                .setName(PROJECTA_PREFIX + PROJECTA_VERSION)
-                .call();
-        git.tag()
-                .setAnnotated(false)
-                .setName(PROJECTB_PREFIX + PROJECTB_VERSION)
-                .call();
+        git.tag().setAnnotated(false).setName(projectAPrefix + projectAVersion).call();
+        git.tag().setAnnotated(false).setName(projectBPrefix + projectBVersion).call();
 
-        assertThat(versionDetails(PROJECTA_PREFIX).getVersion()).isEqualTo(PROJECTA_VERSION);
-        assertThat(versionDetails(PROJECTB_PREFIX).getVersion()).isEqualTo(PROJECTB_VERSION);
+        assertThat(versionDetails(projectAPrefix).getVersion()).isEqualTo(projectAVersion);
+        assertThat(versionDetails(projectBPrefix).getVersion()).isEqualTo(projectBVersion);
     }
 
     private File write(File file) throws IOException {


### PR DESCRIPTION
This PR builds on https://github.com/palantir/gradle-git-version/pull/342

Tags can have digits and minus signs.  Prefixes should also allow them.