### PR TITLE
Allow numbers in prefix argument

### DIFF
--- a/src/main/java/com/palantir/gradle/gitversion/GitVersionArgs.java
+++ b/src/main/java/com/palantir/gradle/gitversion/GitVersionArgs.java
@@ -20,7 +20,7 @@ import com.google.common.base.Preconditions;
 import java.util.Map;
 
 class GitVersionArgs {
-    private static final String PREFIX_REGEX = "[/@]?([A-Za-z]+[/@-])+";
+    private static final String PREFIX_REGEX = "[/@]?([A-Za-z][0-9A-Za-z]*[/@-])+";
 
     private String prefix = "";
 


### PR DESCRIPTION
Allow numbers in prefix

## Before this PR
Tags with numbers in them are rejected as prefixes.  For example, p123@ would be rejected.

## After this PR
Tags with number them are not rejected.  Prefixes that start with a number would still be rejected.

## Possible downsides?
I'm unable to build and test this, so I'm not sure if the numbers cause an issue downstream.

