### PR TITLE
remove test case related to gradle 5

### DIFF
--- a/changelog/@unreleased/pr-684.v2.yml
+++ b/changelog/@unreleased/pr-684.v2.yml
@@ -1,0 +1,8 @@
+type: break
+break:
+  description: "\n1. Caching is added to `gitVersion()` or `versionDetails()` to avoid
+    long configuration time caused by repeatedly calling git describe on subprojects.
+    \n2. The implementation uses BuildService which is introduced in Gradle 6.1. Therefore,
+    any version before Gradle 6.1 won't be supported. "
+  links:
+  - https://github.com/palantir/gradle-git-version/pull/684

--- a/src/main/java/com/palantir/gradle/gitversion/GitVersionCacheService.java
+++ b/src/main/java/com/palantir/gradle/gitversion/GitVersionCacheService.java
@@ -1,0 +1,97 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.gradle.gitversion;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class GitVersionCacheService implements BuildService<BuildServiceParameters.None> {
+
+    private static final Logger log = LoggerFactory.getLogger(GitVersionCacheService.class);
+
+    private final Timer timer = new Timer();
+    private final ConcurrentMap<String, VersionDetails> versionDetailsMap = new ConcurrentHashMap<>();
+
+    public final String getGitVersion(File project, Object args) {
+        File gitDir = getRootGitDir(project);
+        GitVersionArgs gitVersionArgs = GitVersionArgs.fromGroovyClosure(args);
+        String key = gitDir.toPath() + "|" + gitVersionArgs.getPrefix();
+        String gitVersion = versionDetailsMap
+                .computeIfAbsent(key, _k -> createVersionDetails(gitDir, gitVersionArgs))
+                .getVersion();
+        return gitVersion;
+    }
+
+    public final VersionDetails getVersionDetails(File project, Object args) {
+        File gitDir = getRootGitDir(project);
+        GitVersionArgs gitVersionArgs = GitVersionArgs.fromGroovyClosure(args);
+        String key = gitDir.toPath() + "|" + gitVersionArgs.getPrefix();
+        VersionDetails versionDetails =
+                versionDetailsMap.computeIfAbsent(key, _k -> createVersionDetails(gitDir, gitVersionArgs));
+        return versionDetails;
+    }
+
+    private VersionDetails createVersionDetails(File gitDir, GitVersionArgs args) {
+        try {
+            return TimingVersionDetails.wrap(timer, new VersionDetailsImpl(gitDir, args));
+        } catch (IOException e) {
+            log.debug("Cannot compute version details", e);
+            return null;
+        }
+    }
+
+    public final Timer timer() {
+        return timer;
+    }
+
+    private static File getRootGitDir(File currentRoot) {
+        File gitDir = scanForRootGitDir(currentRoot);
+        if (!gitDir.exists()) {
+            throw new IllegalArgumentException("Cannot find '.git' directory");
+        }
+        return gitDir;
+    }
+
+    private static File scanForRootGitDir(File currentRoot) {
+        File gitDir = new File(currentRoot, ".git");
+
+        if (gitDir.exists()) {
+            return gitDir;
+        }
+
+        // stop at the root directory, return non-existing File object;
+        if (currentRoot.getParentFile() == null) {
+            return gitDir;
+        }
+
+        // look in parent directory;
+        return scanForRootGitDir(currentRoot.getParentFile());
+    }
+
+    public static Provider<GitVersionCacheService> getSharedGitVersionCacheService(Project project) {
+        return project.getGradle()
+                .getSharedServices()
+                .registerIfAbsent("GitVersionCacheService", GitVersionCacheService.class, _spec -> {});
+    }
+}

--- a/src/main/java/com/palantir/gradle/gitversion/GitVersionPlugin.java
+++ b/src/main/java/com/palantir/gradle/gitversion/GitVersionPlugin.java
@@ -17,37 +17,31 @@
 package com.palantir.gradle.gitversion;
 
 import groovy.lang.Closure;
-import java.io.File;
-import java.io.IOException;
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.provider.Provider;
 
 public final class GitVersionPlugin implements Plugin<Project> {
-    private final Timer timer = new Timer();
 
     @Override
     public void apply(final Project project) {
         project.getRootProject().getPluginManager().apply(GitVersionRootPlugin.class);
 
-        final Git git = gitRepo(project);
+        Provider<GitVersionCacheService> serviceProvider =
+                GitVersionCacheService.getSharedGitVersionCacheService(project);
 
         // intentionally not using .getExtension() here for back-compat
         project.getExtensions().getExtraProperties().set("gitVersion", new Closure<String>(this, this) {
             public String doCall(Object args) {
-                return TimingVersionDetails.wrap(
-                                timer, new VersionDetailsImpl(git, GitVersionArgs.fromGroovyClosure(args)))
-                        .getVersion();
+                return serviceProvider.get().getGitVersion(project.getProjectDir(), args);
             }
         });
 
         project.getExtensions().getExtraProperties().set("versionDetails", new Closure<VersionDetails>(this, this) {
             public VersionDetails doCall(Object args) {
-                return TimingVersionDetails.wrap(
-                        timer, new VersionDetailsImpl(git, GitVersionArgs.fromGroovyClosure(args)));
+                return serviceProvider.get().getVersionDetails(project.getProjectDir(), args);
             }
         });
 
@@ -61,42 +55,5 @@ public final class GitVersionPlugin implements Plugin<Project> {
         });
         printVersionTask.setGroup("Versioning");
         printVersionTask.setDescription("Prints the project's configured version to standard out");
-    }
-
-    Timer timer() {
-        return timer;
-    }
-
-    private Git gitRepo(Project project) {
-        try {
-            File gitDir = getRootGitDir(project.getProjectDir());
-            return Git.wrap(new FileRepository(gitDir));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static File getRootGitDir(File currentRoot) {
-        File gitDir = scanForRootGitDir(currentRoot);
-        if (!gitDir.exists()) {
-            throw new IllegalArgumentException("Cannot find '.git' directory");
-        }
-        return gitDir;
-    }
-
-    private static File scanForRootGitDir(File currentRoot) {
-        File gitDir = new File(currentRoot, ".git");
-
-        if (gitDir.exists()) {
-            return gitDir;
-        }
-
-        // stop at the root directory, return non-existing File object;
-        if (currentRoot.getParentFile() == null) {
-            return gitDir;
-        }
-
-        // look in parent directory;
-        return scanForRootGitDir(currentRoot.getParentFile());
     }
 }

--- a/src/main/java/com/palantir/gradle/gitversion/GitVersionRootPlugin.java
+++ b/src/main/java/com/palantir/gradle/gitversion/GitVersionRootPlugin.java
@@ -17,11 +17,9 @@
 package com.palantir.gradle.gitversion;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-import java.util.Map;
-import java.util.stream.Collectors;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
 
 final class GitVersionRootPlugin implements Plugin<Project> {
     @Override
@@ -31,25 +29,19 @@ final class GitVersionRootPlugin implements Plugin<Project> {
                     "The %s plugin must be applied to the root project", GitVersionRootPlugin.class.getSimpleName()));
         }
 
+        Provider<GitVersionCacheService> serviceProvider =
+                GitVersionCacheService.getSharedGitVersionCacheService(project);
+
         BuildScanPluginInterop.addBuildScanCustomValues(project, () -> {
-            Map<String, Timer> projectPathToTimers = project.getAllprojects().stream()
-                    .filter(someProject -> someProject.getPlugins().hasPlugin(GitVersionPlugin.class))
-                    .collect(Collectors.toMap(Project::getPath, someProject -> someProject
-                            .getPlugins()
-                            .getPlugin(GitVersionPlugin.class)
-                            .timer()));
+            Timer timer = serviceProvider.get().timer();
 
-            Map<String, String> projectPathToTimerJson = Maps.transformValues(projectPathToTimers, Timer::toJson);
+            String timerJson = timer.toJson();
 
-            long totalTime = projectPathToTimers.values().stream()
-                    .mapToLong(Timer::totalMillis)
-                    .sum();
-
-            String allProjectTimingData = JsonUtils.mapToJson(projectPathToTimerJson);
+            long totalTime = timer.totalMillis();
 
             return ImmutableMap.of(
                     "com.palantir.git-version.timings",
-                    allProjectTimingData,
+                    timerJson,
                     "com.palantir.git-version.timings.total",
                     Long.toString(totalTime));
         });

--- a/src/main/java/com/palantir/gradle/gitversion/VersionDetailsImpl.java
+++ b/src/main/java/com/palantir/gradle/gitversion/VersionDetailsImpl.java
@@ -17,11 +17,13 @@
 package com.palantir.gradle.gitversion;
 
 import com.google.common.base.Preconditions;
+import java.io.File;
 import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
@@ -37,8 +39,8 @@ final class VersionDetailsImpl implements VersionDetails {
     private final GitVersionArgs args;
     private volatile String maybeCachedDescription = null;
 
-    VersionDetailsImpl(Git git, GitVersionArgs args) {
-        this.git = git;
+    VersionDetailsImpl(File gitDir, GitVersionArgs args) throws IOException {
+        this.git = Git.wrap(new FileRepository(gitDir));
         this.args = args;
     }
 

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -639,25 +639,6 @@ class GitVersionPluginTests extends Specification {
         buildResult.output.contains(":printVersion\n1.0.0-${depth}-g${commitSha.substring(0, 7)}\n")
     }
 
-    def 'does not crash when setting build scan custom values when Gradle 5 build scan plugin is applied'() {
-        when:
-        buildFile << '''
-            plugins {
-                id 'com.palantir.git-version'
-                id 'com.gradle.build-scan' version '3.2'
-            }
-            version gitVersion()
-        '''.stripIndent()
-        gitIgnoreFile << 'build'
-        Git git = Git.init().setDirectory(projectDir).call()
-        git.add().addFilepattern('.').call()
-        git.commit().setMessage('initial commit').call()
-        git.tag().setAnnotated(true).setMessage('1.0.0').setName('1.0.0').call()
-
-        then:
-        with(Optional.of('5.6.4'), 'printVersion').build()
-    }
-
     def 'does not crash when setting build scan custom values when Gradle 6 enterprise plugin 3.2 is applied'() {
         when:
         settingsFile.text = '''

--- a/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
+++ b/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
@@ -89,12 +89,25 @@ public class VersionDetailsTest {
         assertThat(versionDetails().getVersion()).isEqualTo("6f0c7ed.dirty");
     }
 
+    @Test
+    public void git_version_result_is_being_cached() throws Exception {
+        write(new File(temporaryFolder, "foo"));
+        git.add().addFilepattern(".").call();
+        git.commit().setMessage("initial commit").call();
+        git.tag().setAnnotated(true).setMessage("cached").setName("1.0.0").call();
+        VersionDetails versionDetails = versionDetails();
+        assertThat(versionDetails.getVersion()).isEqualTo("1.0.0");
+        git.tag().setAnnotated(true).setMessage("unused").setName("2.0.0").call();
+        assertThat(versionDetails.getVersion()).isEqualTo("1.0.0");
+    }
+
     private File write(File file) throws IOException {
         Files.write(file.toPath(), "content".getBytes(StandardCharsets.UTF_8));
         return file;
     }
 
-    private VersionDetails versionDetails() {
-        return new VersionDetailsImpl(git, new GitVersionArgs());
+    private VersionDetails versionDetails() throws IOException {
+        File gitDir = new File(temporaryFolder.toString() + "/.git");
+        return new VersionDetailsImpl(gitDir, new GitVersionArgs());
     }
 }


### PR DESCRIPTION
## Before this PR
Gradle5 does not support build service. So if we want to support build service, we cannot support gradle 5.

## After this PR
Gradle 5 won't be supported

## Possible downsides?
current other plugins, e.g. gradle-baseline-java explicitly doesn't support anything less than gradle 7. So we should be fine not supporting gradle 5 here. 

