### PR TITLE
ignore user's global gitconfig

### DIFF
--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -15,6 +15,8 @@
  */
 package com.palantir.gradle.gitversion
 
+import org.eclipse.jgit.util.SystemReader
+
 import java.nio.file.Files
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.MergeCommand
@@ -49,6 +51,8 @@ class GitVersionPluginTests extends Specification {
             rootProject.name = 'gradle-test'
         '''.stripIndent()
         gitIgnoreFile << '.gradle\n'
+        //This allows tests to work in environments where unsupported options are in the user's global .gitconfig
+        SystemReader.getInstance().getUserConfig().clear();
     }
 
     def 'exception when project root does not have a git repo' () {

--- a/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
+++ b/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
@@ -26,7 +26,9 @@ import java.util.Date;
 import java.util.TimeZone;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.ConfigInvalidException;
 import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -43,8 +45,10 @@ public class VersionDetailsTest {
             new PersonIdent("name", "email@address", new Date(1234L), TimeZone.getTimeZone("UTC"));
 
     @BeforeEach
-    public void before() throws GitAPIException {
+    public void before() throws GitAPIException, ConfigInvalidException, IOException {
         git = Git.init().setDirectory(temporaryFolder).call();
+        // This allows tests to work in environments where unsupported options are in the user's global .gitconfig
+        SystemReader.getInstance().getUserConfig().clear();
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
When working on the plugin and running tests, if a user's global .gitconfig contained unsupported options like requiring commit signing, tests would fail.

This is a known/requested issue for jgit:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=488777

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Ignore user's config in tests
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

