### PR TITLE
Esword/custom version formatting

### DIFF
--- a/changelog/@unreleased/pr-697.v2.yml
+++ b/changelog/@unreleased/pr-697.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Allow customization of the version string.
+  links:
+  - https://github.com/palantir/gradle-git-version/pull/697

--- a/src/main/java/com/palantir/gradle/gitversion/GitVersionArgs.java
+++ b/src/main/java/com/palantir/gradle/gitversion/GitVersionArgs.java
@@ -24,6 +24,8 @@ class GitVersionArgs {
 
     private String prefix = "";
 
+    private VersionFormatter formatter;
+
     public String getPrefix() {
         return prefix;
     }
@@ -40,12 +42,27 @@ class GitVersionArgs {
         this.prefix = prefix;
     }
 
+    public VersionFormatter getFormatter() {
+        return formatter;
+    }
+
+    public void setFormatter(VersionFormatter formatter) {
+        this.formatter = formatter;
+    }
+
     // groovy closure invocation allows any number of args
     @SuppressWarnings("rawtypes")
     static GitVersionArgs fromGroovyClosure(Object... objects) {
         if (objects != null && objects.length > 0 && objects[0] instanceof Map) {
             GitVersionArgs instance = new GitVersionArgs();
-            instance.setPrefix(((Map) objects[0]).get("prefix").toString());
+            Map argsMap = (Map) objects[0];
+            instance.setPrefix(argsMap.get("prefix").toString());
+            Object maybeFormatter = argsMap.get("formatter");
+            if (maybeFormatter != null) {
+                Preconditions.checkArgument(
+                        (maybeFormatter instanceof VersionFormatter), "formatter must be a VersionFormatter");
+                instance.setFormatter((VersionFormatter) maybeFormatter);
+            }
             return instance;
         }
 

--- a/src/main/java/com/palantir/gradle/gitversion/VersionFormatter.java
+++ b/src/main/java/com/palantir/gradle/gitversion/VersionFormatter.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,24 +16,16 @@
 
 package com.palantir.gradle.gitversion;
 
-import java.io.IOException;
+public interface VersionFormatter {
+    default String format(VersionDetails details) {
+        if (details.getDescription() == null) {
+            return "unspecified";
+        }
 
-public interface VersionDetails {
-    String getBranchName() throws IOException;
+        return details.getDescription() + (details.isClean() ? "" : ".dirty");
+    }
 
-    String getGitHashFull() throws IOException;
-
-    String getGitHash() throws IOException;
-
-    String getLastTag();
-
-    int getCommitDistance();
-
-    boolean getIsCleanTag();
-
-    String getVersion();
-
-    String getDescription();
-
-    boolean isClean();
+    static VersionFormatter defaultFormatter() {
+        return new VersionFormatter() {};
+    }
 }

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -15,6 +15,8 @@
  */
 package com.palantir.gradle.gitversion
 
+import org.eclipse.jgit.util.SystemReader
+
 import java.nio.file.Files
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.MergeCommand
@@ -49,6 +51,8 @@ class GitVersionPluginTests extends Specification {
             rootProject.name = 'gradle-test'
         '''.stripIndent()
         gitIgnoreFile << '.gradle\n'
+        //This allows tests to work in environments where unsupported options are in the user's global .gitconfig
+        SystemReader.getInstance().getUserConfig().clear();
     }
 
     def 'exception when project root does not have a git repo' () {

--- a/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
+++ b/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
@@ -26,7 +26,9 @@ import java.util.Date;
 import java.util.TimeZone;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.ConfigInvalidException;
 import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -43,8 +45,10 @@ public class VersionDetailsTest {
             new PersonIdent("name", "email@address", new Date(1234L), TimeZone.getTimeZone("UTC"));
 
     @BeforeEach
-    public void before() throws GitAPIException {
+    public void before() throws GitAPIException, ConfigInvalidException, IOException {
         git = Git.init().setDirectory(temporaryFolder).call();
+        // This allows tests to work in environments where unsupported options are in the user's global .gitconfig
+        SystemReader.getInstance().getUserConfig().clear();
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
Projects that use git information for versions but have slightly different formatting cannot use the plugin.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow customization of the version string.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

