### PR TITLE
Add debug logs for ./gradlew printVersion

### DIFF
--- a/changelog/@unreleased/pr-717.v2.yml
+++ b/changelog/@unreleased/pr-717.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add debug logs for ./gradlew printVersion
+  links:
+  - https://github.com/palantir/gradle-git-version/pull/717

--- a/src/main/java/com/palantir/gradle/gitversion/Git.java
+++ b/src/main/java/com/palantir/gradle/gitversion/Git.java
@@ -58,6 +58,7 @@ class Git {
         List<String> cmdInput = new ArrayList<>();
         cmdInput.add("git");
         cmdInput.addAll(Arrays.asList(commands));
+        log.debug("Running command: {}", cmdInput);
         ProcessBuilder pb = new ProcessBuilder(cmdInput);
         Map<String, String> environment = pb.environment();
         environment.putAll(envvars);
@@ -80,7 +81,9 @@ class Git {
             return "";
         }
 
-        return builder.toString().trim();
+        String ret = builder.toString().trim();
+        log.debug("Command returned value: {}", ret);
+        return ret;
     }
 
     public String runGitCommand(Map<String, String> envvar, String... command) {

--- a/src/main/java/com/palantir/gradle/gitversion/GitVersionPlugin.java
+++ b/src/main/java/com/palantir/gradle/gitversion/GitVersionPlugin.java
@@ -22,8 +22,12 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.provider.Provider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class GitVersionPlugin implements Plugin<Project> {
+
+    private static final Logger log = LoggerFactory.getLogger(GitVersionPlugin.class);
 
     @Override
     public void apply(final Project project) {
@@ -50,7 +54,9 @@ public final class GitVersionPlugin implements Plugin<Project> {
             @Override
             @SuppressWarnings("BanSystemOut")
             public void execute(Task _task) {
-                System.out.println(project.getVersion());
+                Object version = project.getVersion();
+                log.debug("Determined version for project {} is {}", project.getName(), version);
+                System.out.println(version);
             }
         });
         printVersionTask.setGroup("Versioning");


### PR DESCRIPTION
## Before this PR
In https://github.com/palantir/gradle-git-version/issues/65#issuecomment-1574078590 I as a user was confused about the difference between `./gradlew printVersion` and `println(gitVersion())`.  I thought `./gradlew printVersion` was printing the version that gradle-git-version produced, and not the version of its gradle project.

One of the things I did while debugging was run with `--info | grep -i git` and `--debug | grep -i git`.  I think if that had included the logs included in this PR, I would've been able to determine that the problem was a missing `version gitVersion()` line, and not a bug in my tags or git repo.

## After this PR
==COMMIT_MSG==
Add debug logs for ./gradlew printVersion
==COMMIT_MSG==