### PR TITLE
groovy dependencies no longer needed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,22 +43,9 @@ repositories {
     mavenCentral() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
 }
 
-sourceSets {
-    groovy
-    main.output.dir groovy.output
-}
-
 dependencies {
     implementation gradleApi()
     implementation 'com.google.guava:guava'
-
-    groovyImplementation localGroovy()
-    groovyImplementation gradleApi()
-
-    // Access code written in groovy from src/main/java sources
-    runtimeOnly configurations.groovyRuntimeClasspath
-    implementation configurations.groovyImplementation
-    implementation sourceSets.groovy.output
 
     annotationProcessor 'org.immutables:value'
     compileOnly 'org.immutables:value::annotations'

--- a/changelog/@unreleased/pr-875.v2.yml
+++ b/changelog/@unreleased/pr-875.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: no longer used
+  links:
+  - https://github.com/palantir/gradle-git-version/pull/875


### PR DESCRIPTION
## Before this PR
the groovy dependencies are no longer needed - the performance code was ripped out long ago.  See #807 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

