### PR TITLE
Add GIT_VERSION env var support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ apply plugin: 'com.palantir.failure-reports'
 apply plugin: 'com.palantir.gradle-plugin-testing'
 
 group 'com.palantir.gradle.gitversion'
-version System.env.CIRCLE_TAG ?: gitVersion()
+version gitVersion()
 
 repositories {
     mavenCentral() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ apply plugin: 'com.palantir.failure-reports'
 apply plugin: 'com.palantir.gradle-plugin-testing'
 
 group 'com.palantir.gradle.gitversion'
-version gitVersion()
+version System.env.CIRCLE_TAG ?: gitVersion()
 
 repositories {
     mavenCentral() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }

--- a/changelog/@unreleased/pr-928.v2.yml
+++ b/changelog/@unreleased/pr-928.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Add GIT_VERSION env var support
+  description: Add `GIT_VERSION` env var support
   links:
   - https://github.com/palantir/gradle-git-version/pull/928

--- a/changelog/@unreleased/pr-928.v2.yml
+++ b/changelog/@unreleased/pr-928.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add GIT_VERSION env var support
+  links:
+  - https://github.com/palantir/gradle-git-version/pull/928

--- a/src/main/java/com/palantir/gradle/gitversion/VersionDetailsImpl.java
+++ b/src/main/java/com/palantir/gradle/gitversion/VersionDetailsImpl.java
@@ -43,6 +43,11 @@ final class VersionDetailsImpl implements VersionDetails {
 
     @Override
     public String getVersion() {
+        String envVersion = System.getenv("GIT_VERSION");
+        if (envVersion != null && !envVersion.isEmpty()) {
+            return envVersion;
+        }
+
         if (description() == null) {
             return "unspecified";
         }

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -208,11 +208,8 @@ class GitVersionPluginTests extends Specification {
         git.runGitCommand("commit", "-m", "'initial commit'")
         git.runGitCommand("tag", "-a", "1.0.0", "-m", "1.0.0")
 
-        Map<String, String> env = new HashMap<>()
-        env.put("GIT_VERSION", "999")
-
         when:
-        BuildResult buildResult = with(Optional.empty(), Optional.of(env),'printVersion').build()
+        BuildResult buildResult = with(Optional.empty(), Optional.of(Map.of("GIT_VERSION", "999")),'printVersion').build()
 
         then:
         buildResult.output.contains(":printVersion\n999\n")

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -739,7 +739,8 @@ class GitVersionPluginTests extends Specification {
                 .withArguments(arguments)
 
         gradleVersion.ifPresent({ version -> gradleRunner.withGradleVersion(version) })
-        envVars.ifPresent {env -> gradleRunner.withEnvironment(env)}
+        envVars.ifPresent {env -> gradleRunner.withEnvironment(new HashMap<>(System.getenv()).putAll(env))
+        }
 
         return gradleRunner
     }

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -739,7 +739,10 @@ class GitVersionPluginTests extends Specification {
                 .withArguments(arguments)
 
         gradleVersion.ifPresent({ version -> gradleRunner.withGradleVersion(version) })
-        envVars.ifPresent {env -> gradleRunner.withEnvironment(new HashMap<>(System.getenv()).putAll(env))
+        envVars.ifPresent {env ->
+            Map<String, String> systemEnv = new HashMap<>(System.getenv())
+            systemEnv.putAll(env)
+            gradleRunner.withEnvironment(systemEnv)
         }
 
         return gradleRunner

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -209,10 +209,16 @@ class GitVersionPluginTests extends Specification {
         git.runGitCommand("tag", "-a", "1.0.0", "-m", "1.0.0")
 
         when:
-        BuildResult buildResult = with(Optional.empty(), Optional.of(Map.of("GIT_VERSION", "999")),'printVersion').build()
+        BuildResult normalResult = with('printVersion').build()
 
         then:
-        buildResult.output.contains(":printVersion\n999\n")
+        normalResult.output.contains(":printVersion\n1.0.0\n")
+
+        when:
+        BuildResult overriddenResult = with(Optional.empty(), Optional.of(Map.of("GIT_VERSION", "999")),'printVersion').build()
+
+        then:
+        overriddenResult.output.contains(":printVersion\n999\n")
     }
 
     def 'git describe when lightweight tag is present' () {

--- a/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/gitversion/GitVersionPluginTests.groovy
@@ -193,6 +193,31 @@ class GitVersionPluginTests extends Specification {
         buildResult.output.contains(":printVersion\n1.0.0\n")
     }
 
+    def 'gitVersion() uses GIT_VERSION environment variable if it is set' () {
+        given:
+        buildFile << '''
+            plugins {
+                id 'com.palantir.git-version'
+            }
+            version gitVersion()
+        '''.stripIndent()
+        gitIgnoreFile << 'build'
+        Git git = new Git(projectDir, true)
+        git.runGitCommand("init", projectDir.toString())
+        git.runGitCommand("add", ".")
+        git.runGitCommand("commit", "-m", "'initial commit'")
+        git.runGitCommand("tag", "-a", "1.0.0", "-m", "1.0.0")
+
+        Map<String, String> env = new HashMap<>()
+        env.put("GIT_VERSION", "999")
+
+        when:
+        BuildResult buildResult = with(Optional.empty(), Optional.of(env),'printVersion').build()
+
+        then:
+        buildResult.output.contains(":printVersion\n999\n")
+    }
+
     def 'git describe when lightweight tag is present' () {
         given:
         buildFile << '''
@@ -701,10 +726,10 @@ class GitVersionPluginTests extends Specification {
     }
 
     private GradleRunner with(String... tasks) {
-        return with(Optional.empty(), tasks)
+        return with(Optional.empty(), Optional.empty(), tasks)
     }
 
-    private GradleRunner with(Optional<String> gradleVersion, String... tasks) {
+    private GradleRunner with(Optional<String> gradleVersion, Optional<Map<String, String>> envVars, String... tasks) {
         List<String> arguments = new ArrayList<>(['--stacktrace'])
         arguments.addAll(tasks)
 
@@ -714,6 +739,7 @@ class GitVersionPluginTests extends Specification {
                 .withArguments(arguments)
 
         gradleVersion.ifPresent({ version -> gradleRunner.withGradleVersion(version) })
+        envVars.ifPresent {env -> gradleRunner.withEnvironment(env)}
 
         return gradleRunner
     }


### PR DESCRIPTION
## Before this PR
Previously the [gradle guide](https://github.com/palantir/gradle-guide/blob/45c8c702b3c712ede5aa869f078752434d80356d/guide/testing-and-running-your-plugins-locally.md#running-your-plugin-in-other-repos-locally) required users to have this line to there `build.gradle`

```gradle
version System.env.CIRCLE_TAG ?: gitVersion()
```

## After this PR
Now `gradle-git-version` checks for a new ENV VAR `GIT_VERSION` that acts as an override so that users can publish at different versions from default e.g.

`GIT_VERSION=999 ./gradlew pTML`

Without requiring the `CIRCLE_TAG` workaround

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add GIT_VERSION env var support
==COMMIT_MSG==

## Possible downsides?
If this is rolled out we will now use `gitVersion()` all the time and not use `CIRCLE_TAG` this should be okay as I think `CIRCLE_TAG` matches the git version 
