### PR TITLE
Allow numbers in prefixes

### DIFF
--- a/changelog/@unreleased/pr-962.v2.yml
+++ b/changelog/@unreleased/pr-962.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Allow numbers in prefixes.
+  links:
+  - https://github.com/palantir/gradle-git-version/pull/962

--- a/readme.md
+++ b/readme.md
@@ -85,12 +85,12 @@ val gitVersion: groovy.lang.Closure<String> by extra
 gitVersion(mapOf("prefix" to "my-product@")) // -> 2.15.0
 ```
 
-Valid prefixes are defined by the regex `[/@]?([A-Za-z]+[/@-])+`.
+Valid prefixes are defined by the regex `[/@]?([A-Za-z0-9]+[/@-])+`.
 ```
 /Abc/
 Abc@
 foo-bar@
-foo/bar@
+foo/bar-v2@
 ```
 
 Tasks

--- a/src/main/java/com/palantir/gradle/gitversion/GitVersionArgs.java
+++ b/src/main/java/com/palantir/gradle/gitversion/GitVersionArgs.java
@@ -20,7 +20,7 @@ import com.google.common.base.Preconditions;
 import java.util.Map;
 
 class GitVersionArgs {
-    private static final String PREFIX_REGEX = "[/@]?([A-Za-z]+[/@-])+";
+    private static final String PREFIX_REGEX = "[/@]?([A-Za-z0-9]+[/@-])+";
 
     private String prefix = "";
 

--- a/src/test/java/com/palantir/gradle/gitversion/GitVersionArgsTest.java
+++ b/src/test/java/com/palantir/gradle/gitversion/GitVersionArgsTest.java
@@ -32,6 +32,7 @@ public class GitVersionArgsTest {
         new GitVersionArgs().setPrefix("foo-bar-");
         new GitVersionArgs().setPrefix("foo/bar@");
         new GitVersionArgs().setPrefix("Foo/Bar@");
+        new GitVersionArgs().setPrefix("@foo-v3@");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Prefixes were restricted to `[/@]?([A-Za-z]+[/@-])+`, which meant numbers were not allowed. Tags whose product names included numbers, e.g. `@foo/my-product-v2@` or `@a2z/my-product` were not compatible, even though there is no risk to allowing them.

When the feature was added, there was discussion about scoping down the valid prefix space, but the conclusion was that numbers should be fine ([link](https://github.com/palantir/gradle-git-version/pull/61#discussion_r353129294)).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow numbers in prefixes.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
There's probably an argument to not allow prefixes to start with a number, but because the prefix must end with a delimiter, I don't think it's necessary to enforce that.