### PR TITLE
Use `com.palantir.gradle.plugintesting.ConfigurationCacheSpec`

### DIFF
--- a/changelog/@unreleased/pr-1019.v2.yml
+++ b/changelog/@unreleased/pr-1019.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use `com.palantir.gradle.plugintesting.ConfigurationCacheSpec`
+  links:
+  - https://github.com/palantir/gradle-git-version/pull/1019

--- a/src/test/groovy/com/palantir/gradle/ConfigurationCacheTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/ConfigurationCacheTest.groovy
@@ -16,9 +16,9 @@
 
 package com.palantir.gradle
 
-import nebula.test.IntegrationTestKitSpec
+import com.palantir.gradle.plugintesting.ConfigurationCacheSpec
 
-class ConfigurationCacheTest extends IntegrationTestKitSpec {
+class ConfigurationCacheTest extends ConfigurationCacheSpec {
 
     def setup() {
         definePluginOutsideOfPluginBlock = true
@@ -40,7 +40,7 @@ class ConfigurationCacheTest extends IntegrationTestKitSpec {
         """)
 
         expect:
-        runTasksWithConfigurationCache('classes')
+        runTasksWithConfigurationCacheAndCheck('classes')
     }
 
     def "classes task runs with configuration cache when using versionDetails()"() {
@@ -61,7 +61,7 @@ class ConfigurationCacheTest extends IntegrationTestKitSpec {
         """)
 
         expect:
-        runTasksWithConfigurationCache('classes')
+        runTasksWithConfigurationCacheAndCheck('classes')
     }
 
     /**
@@ -70,21 +70,5 @@ class ConfigurationCacheTest extends IntegrationTestKitSpec {
     private void setupBuildWithGitVersion(String buildFileContent) {
         // language=Gradle
         buildFile << buildFileContent.stripIndent(true)
-    }
-
-    /**
-     * Runs the specified tasks twice with configuration cache and verifies cache behavior.
-     * Returns true if the configuration cache was properly used on the second run.
-     */
-    private boolean runTasksWithConfigurationCache(String... tasks) {
-        def firstRun = createRunner(tasks + ['--configuration-cache'] as String[]).build()
-        assert firstRun.output.contains('Configuration cache entry stored.'),
-                "Expected first run to store configuration cache, but output was: ${firstRun.output}"
-
-        def secondRun = createRunner(tasks + ['--configuration-cache'] as String[]).build()
-        assert secondRun.output.contains('Configuration cache entry reused.'),
-                "Expected second run to reuse configuration cache, but output was: ${secondRun.output}"
-
-        return true
     }
 }


### PR DESCRIPTION
## Before this PR
Had our own way of running configuration cache tests

## After this PR
Now we use the same shared spec from `plugintesting` rather than having it re-implemented everywhere

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Use `com.palantir.gradle.plugintesting.ConfigurationCacheSpec`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

