### PR TITLE
Introduce Commit Count in VersionDetails

### DIFF
--- a/src/main/java/com/palantir/gradle/gitversion/VersionDetails.java
+++ b/src/main/java/com/palantir/gradle/gitversion/VersionDetails.java
@@ -32,4 +32,6 @@ public interface VersionDetails {
     boolean getIsCleanTag();
 
     String getVersion();
+
+    Long getCommitCount();
 }

--- a/src/main/java/com/palantir/gradle/gitversion/VersionDetailsImpl.java
+++ b/src/main/java/com/palantir/gradle/gitversion/VersionDetailsImpl.java
@@ -36,6 +36,7 @@ class VersionDetailsImpl implements VersionDetails {
     private Provider<Boolean> isClean;
     private Provider<String> gitHashFull;
     private Provider<String> branchName;
+    private Provider<Long> commitCount;
 
     VersionDetailsImpl(ProviderFactory providerFactory, File gitDir, GitVersionArgs gitVersionArgs) {
         String projectDir = gitDir.getParent();
@@ -53,6 +54,14 @@ class VersionDetailsImpl implements VersionDetails {
         this.isClean = git.run("status", "--porcelain").map(String::isEmpty);
         this.gitHashFull = git.run("rev-parse", "HEAD");
         this.branchName = git.run("branch", "--show-current");
+        this.commitCount = git.run("rev-list", "--count", "HEAD").map(rawCount -> {
+            try {
+                return Long.valueOf(rawCount);
+            } catch (Exception e) {
+                System.out.printf(e.getMessage());
+                return 0L;
+            }
+        });
     }
 
     @Override
@@ -66,6 +75,11 @@ class VersionDetailsImpl implements VersionDetails {
             return "unspecified";
         }
         return description() + (isClean() ? "" : ".dirty");
+    }
+
+    @Override
+    public Long getCommitCount() {
+        return commitCount.get();
     }
 
     private boolean isClean() {

--- a/src/main/java/com/palantir/gradle/gitversion/VersionDetailsImpl.java
+++ b/src/main/java/com/palantir/gradle/gitversion/VersionDetailsImpl.java
@@ -58,7 +58,7 @@ class VersionDetailsImpl implements VersionDetails {
             try {
                 return Long.valueOf(rawCount);
             } catch (Exception e) {
-                System.out.printf(e.getMessage());
+                e.printStackTrace();
                 return 0L;
             }
         });

--- a/src/main/java/com/palantir/gradle/gitversion/VersionDetailsImpl.java
+++ b/src/main/java/com/palantir/gradle/gitversion/VersionDetailsImpl.java
@@ -58,7 +58,7 @@ class VersionDetailsImpl implements VersionDetails {
             try {
                 return Long.valueOf(rawCount);
             } catch (Exception e) {
-                e.printStackTrace();
+                log.error("VersionDetailsImpl::getGitHashFull failed", e);
                 return 0L;
             }
         });

--- a/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
+++ b/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
@@ -16,11 +16,7 @@
 
 package com.palantir.gradle.gitversion;
 
-import org.gradle.api.Project;
-import org.gradle.testfixtures.ProjectBuilder;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,8 +25,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class VersionDetailsTest {
 
@@ -61,27 +60,27 @@ public class VersionDetailsTest {
 
         String gitignoreContent =
                 """
-                        # Gradle project files
-                        .gradle/
-                        build/
-                        out/
-                        classes/
-                        
-                        # Gradle wrapper
-                        gradle/
-                        gradlew
-                        gradlew.bat
-                        
-                        # Gradle cache
-                        .gradle/
-                        caches/
-                        
-                        # Local configuration
-                        local.properties
-                        
-                        # Logs
-                        *.log
-                        """;
+                # Gradle project files
+                .gradle/
+                build/
+                out/
+                classes/
+
+                # Gradle wrapper
+                gradle/
+                gradlew
+                gradlew.bat
+
+                # Gradle cache
+                .gradle/
+                caches/
+
+                # Local configuration
+                local.properties
+
+                # Logs
+                *.log
+                """;
 
         try {
             Files.deleteIfExists(gitignoreFile.toPath());

--- a/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
+++ b/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
@@ -16,7 +16,11 @@
 
 package com.palantir.gradle.gitversion;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,11 +29,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
-import org.gradle.api.Project;
-import org.gradle.testfixtures.ProjectBuilder;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class VersionDetailsTest {
 
@@ -60,29 +61,30 @@ public class VersionDetailsTest {
 
         String gitignoreContent =
                 """
-                # Gradle project files
-                .gradle/
-                build/
-                out/
-                classes/
-
-                # Gradle wrapper
-                gradle/
-                gradlew
-                gradlew.bat
-
-                # Gradle cache
-                .gradle/
-                caches/
-
-                # Local configuration
-                local.properties
-
-                # Logs
-                *.log
-                """;
+                        # Gradle project files
+                        .gradle/
+                        build/
+                        out/
+                        classes/
+                        
+                        # Gradle wrapper
+                        gradle/
+                        gradlew
+                        gradlew.bat
+                        
+                        # Gradle cache
+                        .gradle/
+                        caches/
+                        
+                        # Local configuration
+                        local.properties
+                        
+                        # Logs
+                        *.log
+                        """;
 
         try {
+            Files.deleteIfExists(gitignoreFile.toPath());
             Files.write(gitignoreFile.toPath(), gitignoreContent.getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -172,6 +174,28 @@ public class VersionDetailsTest {
 
         assertThat(versionDetails.getVersion()).isEqualTo("1.0.0");
     }
+
+
+    @Test
+    public void git_version_commit_count_returns_correct_count() throws Exception {
+        write(new File(temporaryFolder, "foo"));
+        git.run("add", ".").get();
+        git.run("commit", "-m", "initial commit").get();
+
+        write(new File(temporaryFolder, "bar"));
+        git.run("add", ".").get();
+        git.run("commit", "-m", "second commit").get();
+
+        write(new File(temporaryFolder, "doo"));
+        git.run("add", ".").get();
+        git.run("commit", "-m", "third commit").get();
+
+
+        VersionDetails versionDetails = versionDetails();
+        assertThat(versionDetails.getCommitCount()).isEqualTo(3);
+
+    }
+
 
     private File write(File file) throws IOException {
         Files.write(file.toPath(), "content".getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
+++ b/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
@@ -188,7 +188,6 @@ public class VersionDetailsTest {
         git.run("add", ".").get();
         git.run("commit", "-m", "third commit").get();
 
-
         VersionDetails versionDetails = versionDetails();
         assertThat(versionDetails.getCommitCount()).isEqualTo(3);
     }

--- a/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
+++ b/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
@@ -174,7 +174,6 @@ public class VersionDetailsTest {
         assertThat(versionDetails.getVersion()).isEqualTo("1.0.0");
     }
 
-
     @Test
     public void git_version_commit_count_returns_correct_count() throws Exception {
         write(new File(temporaryFolder, "foo"));
@@ -192,9 +191,7 @@ public class VersionDetailsTest {
 
         VersionDetails versionDetails = versionDetails();
         assertThat(versionDetails.getCommitCount()).isEqualTo(3);
-
     }
-
 
     private File write(File file) throws IOException {
         Files.write(file.toPath(), "content".getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION

## Before this PR

Currently, `gradle-git-version` does not provide the total commit count of the repository. Many Android projects rely on this count to set `versionCode`, forcing them to implement custom scripts or workarounds.

## After this PR

A new property `totalCommits` is exposed, allowing users to access the total number of commits directly from the plugin. Android projects can now set `versionCode` using:

```groovy
android {
    defaultConfig {
        versionCode gitVersion.commitCount
        versionName gitVersion.lastTag  
   }
}
```

\==COMMIT\_MSG==
Add `totalCommits` property to expose the repository's total commit count for versioning.
\==COMMIT\_MSG==

## Possible downsides?

* Users who don’t need the commit count will see a minor increase in plugin computation time when querying Git metadata.
* Projects relying on older Git versions may encounter compatibility issues if commit count retrieval fails.
