### PR TITLE
Add originUrl to versionDetails

### DIFF
--- a/src/main/java/com/palantir/gradle/gitversion/VersionDetails.java
+++ b/src/main/java/com/palantir/gradle/gitversion/VersionDetails.java
@@ -32,4 +32,6 @@ public interface VersionDetails {
     boolean getIsCleanTag();
 
     String getVersion();
+
+    String getOriginUrl();
 }

--- a/src/main/java/com/palantir/gradle/gitversion/VersionDetailsImpl.java
+++ b/src/main/java/com/palantir/gradle/gitversion/VersionDetailsImpl.java
@@ -36,6 +36,7 @@ class VersionDetailsImpl implements VersionDetails {
     private Provider<Boolean> isClean;
     private Provider<String> gitHashFull;
     private Provider<String> branchName;
+    private Provider<String> originUrl;
 
     VersionDetailsImpl(ProviderFactory providerFactory, File gitDir, GitVersionArgs gitVersionArgs) {
         String projectDir = gitDir.getParent();
@@ -53,6 +54,7 @@ class VersionDetailsImpl implements VersionDetails {
         this.isClean = git.run("status", "--porcelain").map(String::isEmpty);
         this.gitHashFull = git.run("rev-parse", "HEAD");
         this.branchName = git.run("branch", "--show-current");
+        this.originUrl = git.run("config", "remote.origin.url");
     }
 
     @Override
@@ -132,6 +134,16 @@ class VersionDetailsImpl implements VersionDetails {
             return Strings.emptyToNull(this.branchName.get());
         } catch (RuntimeException e) {
             log.error("VersionDetailsImpl::getBranchName failed", e);
+            return null;
+        }
+    }
+
+    @Override
+    public String getOriginUrl() {
+        try {
+            return Strings.emptyToNull(this.originUrl.get());
+        } catch (RuntimeException e) {
+            log.error("VersionDetailsImpl::getOriginUrl failed", e);
             return null;
         }
     }

--- a/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
+++ b/src/test/java/com/palantir/gradle/gitversion/VersionDetailsTest.java
@@ -53,6 +53,7 @@ public class VersionDetailsTest {
         git.run("config", "tag.forcesignannotated", "false").get();
         git.run("config", "user.email", "email@example.com").get();
         git.run("config", "user.name", "name").get();
+        git.run("remote", "add", "origin", "git@github.com:example/example.git").get();
     }
 
     private void createGitIgnore(File dir) {
@@ -170,6 +171,17 @@ public class VersionDetailsTest {
         git.run("tag", "-a", "2.0.0", "-m", "unused").get();
 
         assertThat(versionDetails.getVersion()).isEqualTo("1.0.0");
+    }
+
+    @Test
+    public void git_origin_url_result_is_being_cached() throws Exception {
+        write(new File(temporaryFolder, "foo"));
+        VersionDetails versionDetails = versionDetails();
+        assertThat(versionDetails.getOriginUrl()).isEqualTo("git@github.com:example/example.git");
+
+        git.run("remote", "set-url", "origin", "git@github.com:example/example2.git")
+                .get();
+        assertThat(versionDetails.getOriginUrl()).isEqualTo("git@github.com:example/example.git");
     }
 
     private File write(File file) throws IOException {


### PR DESCRIPTION
## Changes

Adds `getOriginUrl()` method to `VersionDetails` interface to expose the git remote origin URL


==COMMIT_MSG==
Add originUrl to versionDetails to get the value of `git config remote.origin.url`
==COMMIT_MSG==