### PR TITLE
Remove throws IOException from VersionDetails.getBranchName

### DIFF
--- a/src/main/java/com/palantir/gradle/gitversion/GitVersionPlugin.java
+++ b/src/main/java/com/palantir/gradle/gitversion/GitVersionPlugin.java
@@ -17,7 +17,6 @@
 package com.palantir.gradle.gitversion;
 
 import groovy.lang.Closure;
-import javax.inject.Inject;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -25,13 +24,6 @@ import org.gradle.api.Task;
 import org.gradle.api.provider.Provider;
 
 public final class GitVersionPlugin implements Plugin<Project> {
-
-    private final Project pluginProject;
-
-    @Inject
-    public GitVersionPlugin(Project project) {
-        this.pluginProject = project;
-    }
 
     @Override
     public void apply(final Project project) {
@@ -66,9 +58,5 @@ public final class GitVersionPlugin implements Plugin<Project> {
             task.setGroup("Versioning");
             task.setDescription("Prints the project's configured version to standard out");
         });
-    }
-
-    public Provider<GitVersionCacheService> getCacheService() {
-        return GitVersionCacheService.getSharedGitVersionCacheService(pluginProject);
     }
 }

--- a/src/main/java/com/palantir/gradle/gitversion/GitVersionPlugin.java
+++ b/src/main/java/com/palantir/gradle/gitversion/GitVersionPlugin.java
@@ -36,6 +36,7 @@ public final class GitVersionPlugin implements Plugin<Project> {
     }
 
     @Override
+    @SuppressWarnings("HiddenField")
     public void apply(final Project project) {
         project.getRootProject().getPluginManager().apply(GitVersionRootPlugin.class);
 

--- a/src/main/java/com/palantir/gradle/gitversion/GitVersionPlugin.java
+++ b/src/main/java/com/palantir/gradle/gitversion/GitVersionPlugin.java
@@ -26,19 +26,19 @@ import org.gradle.api.provider.Provider;
 
 public final class GitVersionPlugin implements Plugin<Project> {
 
-    private Project project;
-    private Provider<GitVersionCacheService> serviceProvider;
+    private final Project pluginProject;
 
     @Inject
     public GitVersionPlugin(Project project) {
-        this.project = project;
-        this.serviceProvider = GitVersionCacheService.getSharedGitVersionCacheService(project);
+        this.pluginProject = project;
     }
 
     @Override
-    @SuppressWarnings("HiddenField")
     public void apply(final Project project) {
         project.getRootProject().getPluginManager().apply(GitVersionRootPlugin.class);
+
+        Provider<GitVersionCacheService> serviceProvider =
+                GitVersionCacheService.getSharedGitVersionCacheService(project);
 
         // intentionally not using .getExtension() here for back-compat
         project.getExtensions().getExtraProperties().set("gitVersion", new Closure<String>(this, this) {
@@ -68,8 +68,7 @@ public final class GitVersionPlugin implements Plugin<Project> {
         });
     }
 
-    public Provider<VersionDetails> getVersionDetails() {
-        return serviceProvider.map(
-                gitVersionCacheService -> gitVersionCacheService.getVersionDetails(project.getProjectDir(), null));
+    public Provider<GitVersionCacheService> getCacheService() {
+        return GitVersionCacheService.getSharedGitVersionCacheService(pluginProject);
     }
 }

--- a/src/main/java/com/palantir/gradle/gitversion/GitVersionPlugin.java
+++ b/src/main/java/com/palantir/gradle/gitversion/GitVersionPlugin.java
@@ -17,6 +17,7 @@
 package com.palantir.gradle.gitversion;
 
 import groovy.lang.Closure;
+import javax.inject.Inject;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -25,12 +26,18 @@ import org.gradle.api.provider.Provider;
 
 public final class GitVersionPlugin implements Plugin<Project> {
 
+    private Project project;
+    private Provider<GitVersionCacheService> serviceProvider;
+
+    @Inject
+    public GitVersionPlugin(Project project) {
+        this.project = project;
+        this.serviceProvider = GitVersionCacheService.getSharedGitVersionCacheService(project);
+    }
+
     @Override
     public void apply(final Project project) {
         project.getRootProject().getPluginManager().apply(GitVersionRootPlugin.class);
-
-        Provider<GitVersionCacheService> serviceProvider =
-                GitVersionCacheService.getSharedGitVersionCacheService(project);
 
         // intentionally not using .getExtension() here for back-compat
         project.getExtensions().getExtraProperties().set("gitVersion", new Closure<String>(this, this) {
@@ -58,5 +65,10 @@ public final class GitVersionPlugin implements Plugin<Project> {
             task.setGroup("Versioning");
             task.setDescription("Prints the project's configured version to standard out");
         });
+    }
+
+    public Provider<VersionDetails> getVersionDetails() {
+        return serviceProvider.map(
+                gitVersionCacheService -> gitVersionCacheService.getVersionDetails(project.getProjectDir(), null));
     }
 }

--- a/src/main/java/com/palantir/gradle/gitversion/VersionDetails.java
+++ b/src/main/java/com/palantir/gradle/gitversion/VersionDetails.java
@@ -19,7 +19,7 @@ package com.palantir.gradle.gitversion;
 import java.io.IOException;
 
 public interface VersionDetails {
-    String getBranchName() throws IOException;
+    String getBranchName();
 
     String getGitHashFull() throws IOException;
 


### PR DESCRIPTION
## Summary
Remove unnecessary `throws IOException` from `VersionDetails.getBranchName`

## Why
`VersionDetails.getBranchName` underlying methods don't throw `IOException` and this will make it easier to access the branch name without the need to catch

## Example Use Case
```
# another plugin apply() method

        Provider<VersionDetails> versionDetails = GitVersionCacheService.getSharedGitVersionCacheService(project)
                .map(cacheService -> cacheService.getVersionDetails(project.getProjectDir(), null));
        Provider<String> originUrl = versionDetails.map(VersionDetails::getOriginUrl);
        Provider<String> branch = versionDetails.map(VersionDetails::getBranchName);
```
==COMMIT_MSG==
Remove throws IOException from VersionDetails.getBranchName
==COMMIT_MSG==
