### PR TITLE
Fix potential NPE in getGitHash()

### DIFF
--- a/src/main/java/com/palantir/gradle/gitversion/VersionDetailsImpl.java
+++ b/src/main/java/com/palantir/gradle/gitversion/VersionDetailsImpl.java
@@ -121,7 +121,12 @@ class VersionDetailsImpl implements VersionDetails {
 
     @Override
     public String getGitHash() throws IOException {
-        return getGitHashFull().substring(0, VERSION_ABBR_LENGTH);
+        String shortHash = null;
+        String fullHash = getGitHashFull();
+        if (fullHash != null) {
+            shortHash = fullHash.substring(0, VERSION_ABBR_LENGTH);
+        }
+        return shortHash;
     }
 
     @Override


### PR DESCRIPTION
If getGitHashFull() fails, it will return null. getGitHash() called getGitHashFull() without performing a null check.

## Before this PR
NPE being thrown

## After this PR
No more NPE

## Possible downsides?
None

